### PR TITLE
chore: fix spelling errors in comments

### DIFF
--- a/foyer-memory/src/lib.rs
+++ b/foyer-memory/src/lib.rs
@@ -26,13 +26,13 @@
 //!
 //! # Design
 //!
-//! The cache is mainly compused of the following components:
+//! The cache is mainly composed of the following components:
 //! 1. handle             : Carries the cached entry, reference count, pointer links in the eviction container, etc.
 //! 2. indexer            : Indexes cached keys to the handles.
 //! 3. eviction container : Defines the order of eviction. Usually implemented with intrusive data structures.
 //!
 //! Because a handle needs to be referenced and mutated by both the indexer and the eviction container in the same
-//! thread, it is hard to implement in 100% safe Rust without overhead. So, the APIs of the indexer and the eviciton
+//! thread, it is hard to implement in 100% safe Rust without overhead. So, the APIs of the indexer and the eviction
 //! container are defined with `NonNull` pointers of the handles.
 //!
 //! When some entry is inserted into the cache, the associated handle should be transmuted into pointer without


### PR DESCRIPTION
## What's changed and what's your intention?

fix typos

## Checklist

- [ ] I have written the necessary rustdoc comments
- [ ] I have added the necessary unit tests and integration tests
- [ ] I have passed `make all` (or `make fast` instead if the old tests are not modified) in my local environment.

## Related issues or PRs (optional)
