### PR TITLE
fix: hide unnecessary error on load error

### DIFF
--- a/foyer-storage/src/compress.rs
+++ b/foyer-storage/src/compress.rs
@@ -14,11 +14,9 @@
 
 // TODO(MrCroxx): unify compress interface?
 
-use anyhow::anyhow;
+use crate::error::Error;
 use clap::ValueEnum;
 use serde::{Deserialize, Serialize};
-
-const NOT_SUPPORT: &str = "compression algorithm not support";
 
 /// The compression algorithm of the disk cache.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize, ValueEnum)]
@@ -53,14 +51,14 @@ impl From<Compression> for u8 {
 }
 
 impl TryFrom<u8> for Compression {
-    type Error = anyhow::Error;
+    type Error = Error;
 
     fn try_from(value: u8) -> Result<Self, Self::Error> {
         match value {
             0 => Ok(Self::None),
             1 => Ok(Self::Zstd),
             2 => Ok(Self::Lz4),
-            _ => Err(anyhow!(NOT_SUPPORT)),
+            _ => Err(Error::CompressionAlgorithmNotSupported(value)),
         }
     }
 }

--- a/foyer-storage/src/compress.rs
+++ b/foyer-storage/src/compress.rs
@@ -14,9 +14,10 @@
 
 // TODO(MrCroxx): unify compress interface?
 
-use crate::error::Error;
 use clap::ValueEnum;
 use serde::{Deserialize, Serialize};
+
+use crate::error::Error;
 
 /// The compression algorithm of the disk cache.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize, ValueEnum)]

--- a/foyer-storage/src/error.rs
+++ b/foyer-storage/src/error.rs
@@ -27,7 +27,7 @@ pub enum Error {
     /// Multiple error list.
     Multiple(MultipleError),
     /// Entry magic mismatch.
-    #[error("magiac mismatch, expected: {expected}, get: {get}")]
+    #[error("magic mismatch, expected: {expected}, get: {get}")]
     MagicMismatch {
         /// Expected magic.
         expected: u32,
@@ -42,6 +42,9 @@ pub enum Error {
         /// Gotten checksum.
         get: u64,
     },
+    /// Compression algorithm not supported.
+    #[error("compression algorithm not supported: {0}")]
+    CompressionAlgorithmNotSupported(u8),
     /// Other error.
     #[error(transparent)]
     Other(#[from] anyhow::Error),

--- a/foyer-storage/src/large/serde.rs
+++ b/foyer-storage/src/large/serde.rs
@@ -65,18 +65,8 @@ impl EntryHeader {
         let checksum = buf.get_u64();
 
         let v = buf.get_u32();
-        let compression = Compression::try_from(v as u8)?;
 
-        let this = Self {
-            key_len,
-            value_len,
-            hash,
-            sequence,
-            compression,
-            checksum,
-        };
-
-        tracing::trace!("{this:#?}");
+        tracing::trace!("read entry header, key len: {key_len}, value_len: {value_len}, hash: {hash}, sequence: {sequence}, checksum: {checksum}, extra: {v}");
 
         let magic = v & ENTRY_MAGIC_MASK;
         if magic != ENTRY_MAGIC {
@@ -85,7 +75,15 @@ impl EntryHeader {
                 get: magic,
             });
         }
+        let compression = Compression::try_from(v as u8)?;
 
-        Ok(this)
+        Ok(Self {
+            key_len,
+            value_len,
+            hash,
+            sequence,
+            checksum,
+            compression,
+        })
     }
 }


### PR DESCRIPTION
## What's changed and what's your intention?

> Please explain **IN DETAIL** what the changes are in this PR and why they are needed. :D

As title. Hide compression error, magic mismatch error and checksum mismatch error with `fn load()`.

## Checklist

- [x] I have written the necessary rustdoc comments
- [x] I have added the necessary unit tests and integration tests
- [x] I have passed `make all` (or `make fast` instead if the old tests are not modified) in my local environment.

## Related issues or PRs (optional)
fix #678 