### PR TITLE
fix: build on windows

### DIFF
--- a/.github/template/template.yml
+++ b/.github/template/template.yml
@@ -38,7 +38,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-latest, macos-latest]
+        os: [ubuntu-latest, macos-latest, windows-latest]
     runs-on: ${{ matrix.os }}
     steps:
       - name: Checkout
@@ -71,7 +71,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-latest, macos-latest]
+        os: [ubuntu-latest, macos-latest, windows-latest]
     runs-on: ${{ matrix.os }}
     steps:
       - name: Checkout
@@ -106,7 +106,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-latest, macos-latest]
+        os: [ubuntu-latest, macos-latest, windows-latest]
         rust_toolchain: [stable, 1.77]
     runs-on: ${{ matrix.os }}
     steps:

--- a/.github/template/template.yml
+++ b/.github/template/template.yml
@@ -131,6 +131,12 @@ jobs:
         if: steps.cache.outputs.cache-hit != 'true'
         run: |
           cargo install cargo-sort --locked
+      - name: Install NASM for aws-lc-rs on Windows
+        if: runner.os == 'Windows'
+        uses: ilammy/setup-nasm@v1
+      - name: Install ninja-build tool for aws-lc-fips-sys on Windows
+        if: runner.os == 'Windows'
+        uses: seanmiddleditch/gha-setup-ninja@v5
       - name: Run rust cargo-sort check
         # https://github.com/DevinR528/cargo-sort/issues/56
         if: matrix.os != 'windows-latest'
@@ -173,7 +179,7 @@ jobs:
           cargo llvm-cov --no-report run --features "mtrace,jaeger" --example tail_based_tracing
           cargo llvm-cov --no-report run --features "mtrace,ot" --example tail_based_tracing
       - name: Run foyer-bench with coverage
-        if: matrix.os == 'ubuntu-latest'
+        if: runner.os == "Linux"
         env:
           RUST_BACKTRACE: 1
           CI: true
@@ -184,7 +190,7 @@ jobs:
         run: |
           cargo llvm-cov report --lcov --output-path lcov.info
       - uses: codecov/codecov-action@v4
-        if: matrix.os == 'ubuntu-latest' && matrix.rust_toolchain == 'stable'
+        if: runner.os == "Linux" && matrix.rust_toolchain == 'stable'
         env:
           CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
         with:

--- a/.github/template/template.yml
+++ b/.github/template/template.yml
@@ -132,6 +132,8 @@ jobs:
         run: |
           cargo install cargo-sort --locked
       - name: Run rust cargo-sort check
+        # https://github.com/DevinR528/cargo-sort/issues/56
+        if: matrix.os != 'windows-latest'
         run: |
           cargo sort -w -c
       - name: Run rust format check

--- a/.github/template/template.yml
+++ b/.github/template/template.yml
@@ -179,7 +179,7 @@ jobs:
           cargo llvm-cov --no-report run --features "mtrace,jaeger" --example tail_based_tracing
           cargo llvm-cov --no-report run --features "mtrace,ot" --example tail_based_tracing
       - name: Run foyer-bench with coverage
-        if: runner.os == "Linux"
+        if: runner.os == 'Linux'
         env:
           RUST_BACKTRACE: 1
           CI: true
@@ -190,7 +190,7 @@ jobs:
         run: |
           cargo llvm-cov report --lcov --output-path lcov.info
       - uses: codecov/codecov-action@v4
-        if: runner.os == "Linux" && matrix.rust_toolchain == 'stable'
+        if: runner.os == 'Linux' && matrix.rust_toolchain == 'stable'
         env:
           CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
         with:

--- a/.github/template/template.yml
+++ b/.github/template/template.yml
@@ -57,6 +57,12 @@ jobs:
             ~/.cargo/registry/cache/
             ~/.cargo/git/db/
           key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.toml') }}-${{ env.CACHE_KEY_SUFFIX }}-rust-udeps
+      - name: Install NASM for aws-lc-rs on Windows
+        if: runner.os == 'Windows'
+        uses: ilammy/setup-nasm@v1
+      - name: Install ninja-build tool for aws-lc-fips-sys on Windows
+        if: runner.os == 'Windows'
+        uses: seanmiddleditch/gha-setup-ninja@v5
       - name: Install cargo-udeps
         if: steps.cache.outputs.cache-hit != 'true'
         run: |

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -185,7 +185,7 @@ jobs:
           cargo llvm-cov --no-report run --features "mtrace,jaeger" --example tail_based_tracing
           cargo llvm-cov --no-report run --features "mtrace,ot" --example tail_based_tracing
       - name: Run foyer-bench with coverage
-        if: runner.os == "Linux"
+        if: runner.os == 'Linux'
         env:
           RUST_BACKTRACE: 1
           CI: true
@@ -196,7 +196,7 @@ jobs:
         run: |
           cargo llvm-cov report --lcov --output-path lcov.info
       - uses: codecov/codecov-action@v4
-        if: runner.os == "Linux" && matrix.rust_toolchain == 'stable'
+        if: runner.os == 'Linux' && matrix.rust_toolchain == 'stable'
         env:
           CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
         with:

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -139,6 +139,7 @@ jobs:
         run: |
           cargo install cargo-sort --locked
       - name: Run rust cargo-sort check
+        if: matrix.os != 'windows-latest'
         run: |
           cargo sort -w -c
       - name: Run rust format check

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -138,6 +138,12 @@ jobs:
         if: steps.cache.outputs.cache-hit != 'true'
         run: |
           cargo install cargo-sort --locked
+      - name: Install NASM for aws-lc-rs on Windows
+        if: runner.os == 'Windows'
+        uses: ilammy/setup-nasm@v1
+      - name: Install ninja-build tool for aws-lc-fips-sys on Windows
+        if: runner.os == 'Windows'
+        uses: seanmiddleditch/gha-setup-ninja@v5
       - name: Run rust cargo-sort check
         if: matrix.os != 'windows-latest'
         run: |
@@ -179,7 +185,7 @@ jobs:
           cargo llvm-cov --no-report run --features "mtrace,jaeger" --example tail_based_tracing
           cargo llvm-cov --no-report run --features "mtrace,ot" --example tail_based_tracing
       - name: Run foyer-bench with coverage
-        if: matrix.os == 'ubuntu-latest'
+        if: runner.os == "Linux"
         env:
           RUST_BACKTRACE: 1
           CI: true
@@ -190,7 +196,7 @@ jobs:
         run: |
           cargo llvm-cov report --lcov --output-path lcov.info
       - uses: codecov/codecov-action@v4
-        if: matrix.os == 'ubuntu-latest' && matrix.rust_toolchain == 'stable'
+        if: runner.os == "Linux" && matrix.rust_toolchain == 'stable'
         env:
           CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
         with:

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -64,6 +64,12 @@ jobs:
             ~/.cargo/registry/cache/
             ~/.cargo/git/db/
           key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.toml') }}-${{ env.CACHE_KEY_SUFFIX }}-rust-udeps
+      - name: Install NASM for aws-lc-rs on Windows
+        if: runner.os == 'Windows'
+        uses: ilammy/setup-nasm@v1
+      - name: Install ninja-build tool for aws-lc-fips-sys on Windows
+        if: runner.os == 'Windows'
+        uses: seanmiddleditch/gha-setup-ninja@v5
       - name: Install cargo-udeps
         if: steps.cache.outputs.cache-hit != 'true'
         run: |

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -45,7 +45,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-latest, macos-latest]
+        os: [ubuntu-latest, macos-latest, windows-latest]
     runs-on: ${{ matrix.os }}
     steps:
       - name: Checkout
@@ -78,7 +78,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-latest, macos-latest]
+        os: [ubuntu-latest, macos-latest, windows-latest]
     runs-on: ${{ matrix.os }}
     steps:
       - name: Checkout
@@ -113,7 +113,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-latest, macos-latest]
+        os: [ubuntu-latest, macos-latest, windows-latest]
         rust_toolchain: [stable, 1.77]
     runs-on: ${{ matrix.os }}
     steps:

--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -63,6 +63,12 @@ jobs:
             ~/.cargo/registry/cache/
             ~/.cargo/git/db/
           key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.toml') }}-${{ env.CACHE_KEY_SUFFIX }}-rust-udeps
+      - name: Install NASM for aws-lc-rs on Windows
+        if: runner.os == 'Windows'
+        uses: ilammy/setup-nasm@v1
+      - name: Install ninja-build tool for aws-lc-fips-sys on Windows
+        if: runner.os == 'Windows'
+        uses: seanmiddleditch/gha-setup-ninja@v5
       - name: Install cargo-udeps
         if: steps.cache.outputs.cache-hit != 'true'
         run: |

--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -184,7 +184,7 @@ jobs:
           cargo llvm-cov --no-report run --features "mtrace,jaeger" --example tail_based_tracing
           cargo llvm-cov --no-report run --features "mtrace,ot" --example tail_based_tracing
       - name: Run foyer-bench with coverage
-        if: runner.os == "Linux"
+        if: runner.os == 'Linux'
         env:
           RUST_BACKTRACE: 1
           CI: true
@@ -195,7 +195,7 @@ jobs:
         run: |
           cargo llvm-cov report --lcov --output-path lcov.info
       - uses: codecov/codecov-action@v4
-        if: runner.os == "Linux" && matrix.rust_toolchain == 'stable'
+        if: runner.os == 'Linux' && matrix.rust_toolchain == 'stable'
         env:
           CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
         with:

--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -138,6 +138,7 @@ jobs:
         run: |
           cargo install cargo-sort --locked
       - name: Run rust cargo-sort check
+        if: matrix.os != 'windows-latest'
         run: |
           cargo sort -w -c
       - name: Run rust format check

--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -44,7 +44,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-latest, macos-latest]
+        os: [ubuntu-latest, macos-latest, windows-latest]
     runs-on: ${{ matrix.os }}
     steps:
       - name: Checkout
@@ -77,7 +77,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-latest, macos-latest]
+        os: [ubuntu-latest, macos-latest, windows-latest]
     runs-on: ${{ matrix.os }}
     steps:
       - name: Checkout
@@ -112,7 +112,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-latest, macos-latest]
+        os: [ubuntu-latest, macos-latest, windows-latest]
         rust_toolchain: [stable, 1.77]
     runs-on: ${{ matrix.os }}
     steps:

--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -137,6 +137,12 @@ jobs:
         if: steps.cache.outputs.cache-hit != 'true'
         run: |
           cargo install cargo-sort --locked
+      - name: Install NASM for aws-lc-rs on Windows
+        if: runner.os == 'Windows'
+        uses: ilammy/setup-nasm@v1
+      - name: Install ninja-build tool for aws-lc-fips-sys on Windows
+        if: runner.os == 'Windows'
+        uses: seanmiddleditch/gha-setup-ninja@v5
       - name: Run rust cargo-sort check
         if: matrix.os != 'windows-latest'
         run: |
@@ -178,7 +184,7 @@ jobs:
           cargo llvm-cov --no-report run --features "mtrace,jaeger" --example tail_based_tracing
           cargo llvm-cov --no-report run --features "mtrace,ot" --example tail_based_tracing
       - name: Run foyer-bench with coverage
-        if: matrix.os == 'ubuntu-latest'
+        if: runner.os == "Linux"
         env:
           RUST_BACKTRACE: 1
           CI: true
@@ -189,7 +195,7 @@ jobs:
         run: |
           cargo llvm-cov report --lcov --output-path lcov.info
       - uses: codecov/codecov-action@v4
-        if: matrix.os == 'ubuntu-latest' && matrix.rust_toolchain == 'stable'
+        if: runner.os == "Linux" && matrix.rust_toolchain == 'stable'
         env:
           CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
         with:

--- a/foyer-common/Cargo.toml
+++ b/foyer-common/Cargo.toml
@@ -15,6 +15,7 @@ bytes = "1"
 cfg-if = "1"
 crossbeam = "0.8"
 fastrace = { workspace = true }
+fs4 = "0.9.1"
 futures = "0.3"
 hashbrown = "0.14"
 itertools = { workspace = true }

--- a/foyer-common/Cargo.toml
+++ b/foyer-common/Cargo.toml
@@ -20,7 +20,6 @@ futures = "0.3"
 hashbrown = "0.14"
 itertools = { workspace = true }
 metrics = { workspace = true }
-nix = { version = "0.29", features = ["fs"] }
 parking_lot = { version = "0.12", features = ["arc_lock"] }
 pin-project = "1"
 serde = { workspace = true }

--- a/foyer-common/src/fs.rs
+++ b/foyer-common/src/fs.rs
@@ -16,7 +16,7 @@ use std::path::Path;
 
 /// Returns the available space. Available space in unix is space reserved for priviliged user +
 /// free space.
-pub fn freespace(path: impl AsRef<Path>) -> Result<u64, std::io::Error> {
+pub fn freespace(path: impl AsRef<Path>) -> std::io::Result<u64> {
     fs4::free_space(path)
 }
 

--- a/foyer-common/src/fs.rs
+++ b/foyer-common/src/fs.rs
@@ -14,7 +14,7 @@
 
 use std::path::Path;
 
-/// Returns the available space. Available space in unix is space reserved for priviliged user +
+/// Returns the available space. Available space in unix is space reserved for privileged user +
 /// free space.
 pub fn freespace(path: impl AsRef<Path>) -> std::io::Result<u64> {
     fs4::free_space(path)

--- a/foyer-common/src/fs.rs
+++ b/foyer-common/src/fs.rs
@@ -14,13 +14,10 @@
 
 use std::path::Path;
 
-use nix::{errno::Errno, sys::statvfs::statvfs};
-
-/// Get the freespace of the device that contains the given path.
-pub fn freespace(path: impl AsRef<Path>) -> Result<usize, Errno> {
-    let stat = statvfs(path.as_ref())?;
-    let res = stat.blocks_available() as usize * stat.fragment_size() as usize;
-    Ok(res)
+/// Returns the available space. Available space in unix is space reserved for priviliged user +
+/// free space.
+pub fn freespace(path: impl AsRef<Path>) -> Result<u64, std::io::Error> {
+    fs4::free_space(path)
 }
 
 #[cfg(test)]
@@ -57,7 +54,7 @@ mod tests {
 
             println!("{}", df);
 
-            assert_eq!(v1, v2);
+            assert_eq!(v1 as usize, v2);
         }
     }
 }

--- a/foyer-common/src/fs.rs
+++ b/foyer-common/src/fs.rs
@@ -16,8 +16,8 @@ use std::path::Path;
 
 /// Returns the available space. Available space in unix is space reserved for privileged user +
 /// free space.
-pub fn freespace(path: impl AsRef<Path>) -> std::io::Result<u64> {
-    fs4::free_space(path)
+pub fn freespace(path: impl AsRef<Path>) -> std::io::Result<usize> {
+    fs4::free_space(path).map(|v| v as usize)
 }
 
 #[cfg(test)]

--- a/foyer-common/src/lib.rs
+++ b/foyer-common/src/lib.rs
@@ -50,5 +50,4 @@ pub mod tracing;
 pub mod wait_group;
 
 /// File system utils.
-#[cfg(any(target_os = "linux", target_os = "macos"))]
 pub mod fs;

--- a/foyer-memory/Cargo.toml
+++ b/foyer-memory/Cargo.toml
@@ -20,7 +20,6 @@ foyer-intrusive = { version = "0.9.1", path = "../foyer-intrusive" }
 futures = "0.3"
 hashbrown = "0.14"
 itertools = { workspace = true }
-libc = "0.2"
 parking_lot = "0.12"
 pin-project = "1"
 serde = { workspace = true }

--- a/foyer-storage/src/device/direct_file.rs
+++ b/foyer-storage/src/device/direct_file.rs
@@ -87,14 +87,12 @@ impl DirectFileDevice {
             capacity = self.capacity,
         );
 
-        #[allow(unused_mut)]
-        let mut file = self.file.clone();
+        let file = self.file.clone();
 
         asyncify_with_runtime(&self.runtime, move || {
             #[cfg(target_family = "windows")]
             let written = {
-                use std::{io::Seek, os::windows::fs::FileExt};
-                let original = file.stream_position()?;
+                use std::os::windows::fs::FileExt;
                 file.seek_write(buf.as_aligned(), offset)?
             };
 
@@ -132,14 +130,12 @@ impl DirectFileDevice {
             buf.set_len(aligned);
         }
 
-        #[allow(unused_mut)]
-        let mut file = self.file.clone();
+        let file = self.file.clone();
 
         let mut buffer = asyncify_with_runtime(&self.runtime, move || {
             #[cfg(target_family = "windows")]
             let read = {
-                use std::{io::Seek, os::windows::fs::FileExt};
-                let original = file.stream_position()?;
+                use std::os::windows::fs::FileExt;
                 file.seek_read(buf.as_mut(), offset)?
             };
 
@@ -308,7 +304,7 @@ impl DirectFileDeviceOptionsBuilder {
             // Create an empty directory before to get freespace.
             let dir = path.parent().expect("path must point to a file").to_path_buf();
             create_dir_all(&dir).unwrap();
-            freespace(&dir).unwrap() as usize / 10 * 8
+            freespace(&dir).unwrap() / 10 * 8
         });
         let capacity = align_v(capacity, ALIGN);
 

--- a/foyer-storage/src/device/direct_file.rs
+++ b/foyer-storage/src/device/direct_file.rs
@@ -12,15 +12,11 @@
 //  See the License for the specific language governing permissions and
 //  limitations under the License.
 
-#[cfg(unix)]
-use std::os::unix::fs::FileExt;
 use std::{
     fs::{create_dir_all, File, OpenOptions},
     path::{Path, PathBuf},
     sync::Arc,
 };
-#[cfg(windows)]
-use std::{io::Seek, os::windows::fs::FileExt};
 
 use foyer_common::{asyncify::asyncify_with_runtime, bits, fs::freespace};
 use serde::{Deserialize, Serialize};
@@ -97,14 +93,16 @@ impl DirectFileDevice {
         asyncify_with_runtime(&self.runtime, move || {
             #[cfg(target_family = "windows")]
             let written = {
+                use std::{io::Seek, os::windows::fs::FileExt};
                 let original = file.stream_position()?;
-                let written = file.seek_write(buf.as_aligned(), offset)?;
-                file.seek(std::io::SeekFrom::Start(original))?;
-                written
+                file.seek_write(buf.as_aligned(), offset)?
             };
 
             #[cfg(target_family = "unix")]
-            let written = { file.write_at(buf.as_aligned(), offset)? };
+            let written = {
+                use std::os::unix::fs::FileExt;
+                file.write_at(buf.as_aligned(), offset)?
+            };
 
             if written != aligned {
                 return Err(anyhow::anyhow!("written {written}, expected: {aligned}").into());
@@ -140,14 +138,16 @@ impl DirectFileDevice {
         let mut buffer = asyncify_with_runtime(&self.runtime, move || {
             #[cfg(target_family = "windows")]
             let read = {
+                use std::{io::Seek, os::windows::fs::FileExt};
                 let original = file.stream_position()?;
-                let read = file.seek_read(buf.as_mut(), offset)?;
-                file.seek(std::io::SeekFrom::Start(original))?;
-                read
+                file.seek_read(buf.as_mut(), offset)?
             };
 
             #[cfg(target_family = "unix")]
-            let read = { file.read_at(buf.as_mut(), offset)? };
+            let read = {
+                use std::os::unix::fs::FileExt;
+                file.read_at(buf.as_mut(), offset)?
+            };
 
             if read != aligned {
                 return Err(anyhow::anyhow!("read {read}, expected: {aligned}").into());

--- a/foyer-storage/src/device/direct_fs.rs
+++ b/foyer-storage/src/device/direct_fs.rs
@@ -162,14 +162,12 @@ impl Dev for DirectFsDevice {
             region_size = self.region_size(),
         );
 
-        #[allow(unused_mut)]
-        let mut file = self.file(region).clone();
+        let file = self.file(region).clone();
 
         asyncify_with_runtime(&self.inner.runtime, move || {
             #[cfg(target_family = "windows")]
             let written = {
-                use std::{io::Seek, os::windows::fs::FileExt};
-                let original = file.stream_position()?;
+                use std::os::windows::fs::FileExt;
                 file.seek_write(buf.as_aligned(), offset)?
             };
 
@@ -206,8 +204,7 @@ impl Dev for DirectFsDevice {
             buf.set_len(aligned);
         }
 
-        #[allow(unused_mut)]
-        let mut file = self.file(region).clone();
+        let file = self.file(region).clone();
 
         let mut buffer = asyncify_with_runtime(&self.inner.runtime, move || {
             #[cfg(target_family = "unix")]
@@ -218,8 +215,7 @@ impl Dev for DirectFsDevice {
 
             #[cfg(target_family = "windows")]
             let read = {
-                use std::{io::Seek, os::windows::fs::FileExt};
-                let original = file.stream_position()?;
+                use std::os::windows::fs::FileExt;
                 file.seek_read(buf.as_mut(), offset)?
             };
 
@@ -306,7 +302,7 @@ impl DirectFsDeviceOptionsBuilder {
         let capacity = self.capacity.unwrap_or({
             // Create an empty directory before to get freespace.
             create_dir_all(&dir).unwrap();
-            freespace(&dir).unwrap() as usize / 10 * 8
+            freespace(&dir).unwrap() / 10 * 8
         });
         let capacity = align_v(capacity, ALIGN);
 

--- a/foyer-storage/src/device/direct_fs.rs
+++ b/foyer-storage/src/device/direct_fs.rs
@@ -168,14 +168,17 @@ impl Dev for DirectFsDevice {
             #[cfg(target_family = "unix")]
             use std::os::unix::fs::FileExt;
             #[cfg(target_family = "windows")]
-            use std::os::windows::fs::FileExt;
+            let written = {
+                let original = file.stream_position()?;
+                file.seek(std::io::SeekFrom::Start(offset))?;
+                let written = file.write(buf.as_aligned())?;
+                file.seek(std::io::SeekFrom::Start(original))?;
+                written
+            };
 
-            let original = file.stream_position()?;
-            file.seek(std::io::SeekFrom::Start(offset))?;
-            let written = file.write(buf.as_aligned())?;
-            //file.seek(std::io::SeekFrom::Start(original))?;
+            #[cfg(target_family = "unix")]
+            let written = file.write_at(buf.as_aligned(), offset)?;
 
-            //let written = file.write_at(buf.as_aligned(), offset)?;
             if written != aligned {
                 return Err(anyhow::anyhow!("written {written}, expected: {aligned}").into());
             }
@@ -207,15 +210,17 @@ impl Dev for DirectFsDevice {
         let mut buffer = asyncify_with_runtime(&self.inner.runtime, move || {
             #[cfg(target_family = "unix")]
             use std::os::unix::fs::FileExt;
+            #[cfg(target_family = "unix")]
+            let read = file.read_at(buf.as_mut(), offset)?;
+
             #[cfg(target_family = "windows")]
-            use std::os::windows::fs::FileExt;
-
-            //let read = file.read_at(buf.as_mut(), offset)?;
-
-            let original = file.stream_position()?;
-            file.seek(std::io::SeekFrom::Start(offset))?;
-            let read = file.read(buf.as_mut())?;
-            //file.seek(std::io::SeekFrom::Start(original))?;
+            let read = {
+                let original = file.stream_position()?;
+                file.seek(std::io::SeekFrom::Start(offset))?;
+                let read = file.read(buf.as_mut())?;
+                file.seek(std::io::SeekFrom::Start(original))?;
+                read
+            };
 
             if read != aligned {
                 return Err(anyhow::anyhow!("read {read}, expected: {aligned}").into());

--- a/foyer-storage/src/device/direct_fs.rs
+++ b/foyer-storage/src/device/direct_fs.rs
@@ -12,17 +12,15 @@
 //  See the License for the specific language governing permissions and
 //  limitations under the License.
 
+#[cfg(unix)]
+use std::os::unix::fs::FileExt;
 use std::{
     fs::{create_dir_all, File, OpenOptions},
     path::{Path, PathBuf},
     sync::Arc,
 };
-
 #[cfg(windows)]
-use std::{os::windows::fs::FileExt, io::Seek};
-
-#[cfg(unix)]
-use std::os::unix::fs::FileExt;
+use std::{io::Seek, os::windows::fs::FileExt};
 
 use foyer_common::{asyncify::asyncify_with_runtime, bits, fs::freespace};
 use futures::future::try_join_all;
@@ -181,10 +179,7 @@ impl Dev for DirectFsDevice {
             };
 
             #[cfg(target_family = "unix")]
-            let written = {
-                file.write_at(buf.as_aligned(), offset)?
-            };
-            
+            let written = { file.write_at(buf.as_aligned(), offset)? };
 
             if written != aligned {
                 return Err(anyhow::anyhow!("written {written}, expected: {aligned}").into());
@@ -218,9 +213,7 @@ impl Dev for DirectFsDevice {
 
         let mut buffer = asyncify_with_runtime(&self.inner.runtime, move || {
             #[cfg(target_family = "unix")]
-            let read = {
-                file.read_at(buf.as_mut(), offset)?
-            };
+            let read = { file.read_at(buf.as_mut(), offset)? };
 
             #[cfg(target_family = "windows")]
             let read = {

--- a/foyer-storage/src/large/generic.rs
+++ b/foyer-storage/src/large/generic.rs
@@ -494,7 +494,11 @@ where
 #[cfg(test)]
 mod tests {
 
-    use std::{fs::File, io::{Seek, SeekFrom, Write}, path::Path};
+    use std::{
+        fs::File,
+        io::{Seek, SeekFrom, Write},
+        path::Path,
+    };
 
     use ahash::RandomState;
     use foyer_memory::{Cache, CacheBuilder, FifoConfig};

--- a/foyer-storage/src/large/generic.rs
+++ b/foyer-storage/src/large/generic.rs
@@ -494,11 +494,7 @@ where
 #[cfg(test)]
 mod tests {
 
-    use std::{
-        fs::File,
-        io::{Seek, SeekFrom, Write},
-        path::Path,
-    };
+    use std::{fs::File, path::Path};
 
     use ahash::RandomState;
     use foyer_memory::{Cache, CacheBuilder, FifoConfig};
@@ -949,9 +945,18 @@ mod tests {
             if !entry.metadata().unwrap().is_file() {
                 continue;
             }
-            let mut file = File::options().write(true).open(entry.path()).unwrap();
-            file.seek(SeekFrom::Start(0)).unwrap();
-            file.write_all(&[b'x'; 4 * 1024]).unwrap();
+
+            let file = File::options().write(true).open(entry.path()).unwrap();
+            #[cfg(target_family = "unix")]
+            {
+                use std::os::unix::fs::FileExt;
+                file.write_all_at(&[b'x'; 4 * 1024], 0).unwrap();
+            }
+            #[cfg(target_family = "windows")]
+            {
+                use std::os::windows::fs::FileExt;
+                file.seek_write(&[b'x'; 4 * 1024], 0).unwrap();
+            }
         }
 
         assert!(store.load(memory.hash(&1)).await.unwrap().is_none());

--- a/foyer-storage/src/large/generic.rs
+++ b/foyer-storage/src/large/generic.rs
@@ -494,7 +494,7 @@ where
 #[cfg(test)]
 mod tests {
 
-    use std::{fs::File, os::unix::fs::FileExt, path::Path};
+    use std::{fs::File, io::{Seek, SeekFrom, Write}, path::Path};
 
     use ahash::RandomState;
     use foyer_memory::{Cache, CacheBuilder, FifoConfig};
@@ -945,8 +945,9 @@ mod tests {
             if !entry.metadata().unwrap().is_file() {
                 continue;
             }
-            let file = File::options().write(true).open(entry.path()).unwrap();
-            file.write_all_at(&[b'x'; 4 * 1024], 0).unwrap();
+            let mut file = File::options().write(true).open(entry.path()).unwrap();
+            file.seek(SeekFrom::Start(0)).unwrap();
+            file.write(&[b'x'; 4 * 1024]).unwrap();
         }
 
         assert!(store.load(memory.hash(&1)).await.unwrap().is_none());

--- a/foyer-storage/src/large/generic.rs
+++ b/foyer-storage/src/large/generic.rs
@@ -951,7 +951,7 @@ mod tests {
             }
             let mut file = File::options().write(true).open(entry.path()).unwrap();
             file.seek(SeekFrom::Start(0)).unwrap();
-            file.write(&[b'x'; 4 * 1024]).unwrap();
+            file.write_all(&[b'x'; 4 * 1024]).unwrap();
         }
 
         assert!(store.load(memory.hash(&1)).await.unwrap().is_none());

--- a/foyer-util/Cargo.toml
+++ b/foyer-util/Cargo.toml
@@ -20,11 +20,13 @@ foyer-common = { path = "../foyer-common" }
 futures = "0.3"
 hashbrown = "0.14"
 itertools = { workspace = true }
-libc = "0.2"
-nix = { version = "0.29", features = ["fs"] }
 parking_lot = { version = "0.12", features = ["arc_lock"] }
 serde = { workspace = true }
 tokio = { workspace = true }
+
+[target.'cfg(unix)'.dependencies]
+libc = "0.2"
+nix = { version = "0.29", features = ["fs"] }
 
 [dev-dependencies]
 rand = "0.8.5"

--- a/foyer-util/src/iostat.rs
+++ b/foyer-util/src/iostat.rs
@@ -26,7 +26,10 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use std::path::{Path, PathBuf};
+use std::path::Path;
+
+#[cfg(unix)]
+use std::path::PathBuf;
 
 use itertools::Itertools;
 #[cfg(unix)]

--- a/foyer-util/src/iostat.rs
+++ b/foyer-util/src/iostat.rs
@@ -29,6 +29,7 @@
 use std::path::{Path, PathBuf};
 
 use itertools::Itertools;
+#[cfg(unix)]
 use nix::{fcntl::readlink, sys::stat::stat};
 
 // TODO(MrCroxx): use `expect` after `lint_reasons` is stable.
@@ -64,6 +65,7 @@ pub fn detect_fs_type(path: impl AsRef<Path>) -> FsType {
 
 /// Given a normal file path, returns the containing block device static file path (of the
 /// partition).
+#[cfg(unix)]
 pub fn file_stat_path(path: impl AsRef<Path>) -> PathBuf {
     let st_dev = stat(path.as_ref()).unwrap().st_dev;
 
@@ -77,6 +79,7 @@ pub fn file_stat_path(path: impl AsRef<Path>) -> PathBuf {
     dev_stat_path(devname.to_str().unwrap())
 }
 
+#[cfg(unix)]
 pub fn dev_stat_path(devname: &str) -> PathBuf {
     let classpath = Path::new("/sys/class/block").join(devname);
     let devclass = readlink(&classpath).unwrap();

--- a/foyer-util/src/iostat.rs
+++ b/foyer-util/src/iostat.rs
@@ -27,7 +27,6 @@
 // limitations under the License.
 
 use std::path::Path;
-
 #[cfg(unix)]
 use std::path::PathBuf;
 


### PR DESCRIPTION
### Currently foyer fails to compile on windows systems. This fixes the errors by adding some line that are cross platform or by adding crates that provide cross platform functionality.

- [x] I have written the necessary rustdoc comments
- [x] I have added the necessary unit tests and integration tests
- [ ] I have passed `make all` (or `make fast` instead if the old tests are not modified) in my local environment.
* the specific steps in the makefile are not compatible with windows. Ran cargo test though* 

close #263 
