### PR TITLE
revert: "perf: introduce size hint for storage ... (#695)"

### DIFF
--- a/foyer-common/src/code.rs
+++ b/foyer-common/src/code.rs
@@ -25,23 +25,13 @@ impl<T: Send + Sync + 'static + std::hash::Hash + Eq> Key for T {}
 impl<T: Send + Sync + 'static> Value for T {}
 
 /// Key trait for the disk cache.
-pub trait StorageKey: Key + Serialize + DeserializeOwned + Hint {}
-impl<T> StorageKey for T where T: Key + Serialize + DeserializeOwned + Hint {}
+pub trait StorageKey: Key + Serialize + DeserializeOwned {}
+impl<T> StorageKey for T where T: Key + Serialize + DeserializeOwned {}
 
 /// Value trait for the disk cache.
-pub trait StorageValue: Value + 'static + Serialize + DeserializeOwned + Hint {}
-impl<T> StorageValue for T where T: Value + Serialize + DeserializeOwned + Hint {}
+pub trait StorageValue: Value + 'static + Serialize + DeserializeOwned {}
+impl<T> StorageValue for T where T: Value + Serialize + DeserializeOwned {}
 
 /// Hash builder trait.
 pub trait HashBuilder: BuildHasher + Send + Sync + 'static {}
 impl<T> HashBuilder for T where T: BuildHasher + Send + Sync + 'static {}
-
-/// Hint functions collection.
-pub trait Hint {
-    /// Size hint for serialization.
-    fn serialized_size_hint(&self) -> usize {
-        0
-    }
-}
-
-impl<T: Send + Sync + 'static> Hint for T {}

--- a/foyer-storage/src/serde.rs
+++ b/foyer-storage/src/serde.rs
@@ -94,17 +94,6 @@ impl EntrySerializer {
 
         Ok(KvInfo { key_len, value_len })
     }
-
-    pub fn size_hint<'a, K, V>(key: &'a K, value: &'a V, compression: &'a Compression) -> usize
-    where
-        K: StorageKey,
-        V: StorageValue,
-    {
-        match compression {
-            Compression::Zstd | Compression::Lz4 => 0,
-            Compression::None => key.serialized_size_hint() + value.serialized_size_hint(),
-        }
-    }
 }
 
 #[derive(Debug)]

--- a/foyer-storage/src/store.rs
+++ b/foyer-storage/src/store.rs
@@ -144,8 +144,7 @@ where
 
         self.inner.write_runtime_handle.spawn(async move {
             if force || this.pick(entry.key()) {
-                let mut buffer =
-                    IoBytesMut::with_capacity(EntrySerializer::size_hint(entry.key(), entry.value(), &compression));
+                let mut buffer = IoBytesMut::new();
                 match EntrySerializer::serialize(
                     entry.key(),
                     entry.value(),


### PR DESCRIPTION
## What's changed and what's your intention?

> Please explain **IN DETAIL** what the changes are in this PR and why they are needed. :D

This reverts commit 260ef1429a658fe8467530f3cd5d7cbae61cd5ee.

Tried with RisingWave. Not a good abstraction, revert.

## Checklist

- [x] I have written the necessary rustdoc comments
- [x] I have added the necessary unit tests and integration tests
- [x] I have passed `make all` (or `make fast` instead if the old tests are not modified) in my local environment.

## Related issues or PRs (optional)
#694 