### PR TITLE
refactor: refine device build

### DIFF
--- a/examples/hybrid.rs
+++ b/examples/hybrid.rs
@@ -12,7 +12,7 @@
 //  See the License for the specific language governing permissions and
 //  limitations under the License.
 
-use foyer::{DirectFsDeviceOptionsBuilder, Engine, HybridCache, HybridCacheBuilder};
+use foyer::{DirectFsDeviceOptions, Engine, HybridCache, HybridCacheBuilder};
 
 #[tokio::main]
 async fn main() -> anyhow::Result<()> {
@@ -21,11 +21,7 @@ async fn main() -> anyhow::Result<()> {
     let hybrid: HybridCache<u64, String> = HybridCacheBuilder::new()
         .memory(64 * 1024 * 1024)
         .storage(Engine::Large) // use large object disk cache engine only
-        .with_device_config(
-            DirectFsDeviceOptionsBuilder::new(dir.path())
-                .with_capacity(256 * 1024 * 1024)
-                .build(),
-        )
+        .with_device_options(DirectFsDeviceOptions::new(dir.path()).with_capacity(256 * 1024 * 1024))
         .build()
         .await?;
 

--- a/examples/hybrid_full.rs
+++ b/examples/hybrid_full.rs
@@ -17,7 +17,7 @@ use std::sync::Arc;
 use anyhow::Result;
 use chrono::Datelike;
 use foyer::{
-    DirectFsDeviceOptionsBuilder, Engine, FifoPicker, HybridCache, HybridCacheBuilder, LargeEngineOptions, LruConfig,
+    DirectFsDeviceOptions, Engine, FifoPicker, HybridCache, HybridCacheBuilder, LargeEngineOptions, LruConfig,
     RateLimitPicker, RecoverMode, RuntimeConfig, SmallEngineOptions, TokioRuntimeConfig, TombstoneLogConfigBuilder,
 };
 use tempfile::tempdir;
@@ -36,11 +36,10 @@ async fn main() -> Result<()> {
         .with_hash_builder(ahash::RandomState::default())
         .with_weighter(|_key, value: &String| value.len())
         .storage(Engine::Mixed(0.1))
-        .with_device_config(
-            DirectFsDeviceOptionsBuilder::new(dir.path())
+        .with_device_options(
+            DirectFsDeviceOptions::new(dir.path())
                 .with_capacity(64 * 1024 * 1024)
-                .with_file_size(4 * 1024 * 1024)
-                .build(),
+                .with_file_size(4 * 1024 * 1024),
         )
         .with_flush(true)
         .with_recover_mode(RecoverMode::Quiet)

--- a/examples/tail_based_tracing.rs
+++ b/examples/tail_based_tracing.rs
@@ -14,7 +14,7 @@
 
 use std::time::Duration;
 
-use foyer::{DirectFsDeviceOptionsBuilder, Engine, HybridCache, HybridCacheBuilder};
+use foyer::{DirectFsDeviceOptions, Engine, HybridCache, HybridCacheBuilder};
 
 #[cfg(feature = "jaeger")]
 fn init_jaeger_exporter() {
@@ -71,11 +71,7 @@ async fn main() -> anyhow::Result<()> {
     let hybrid: HybridCache<u64, String> = HybridCacheBuilder::new()
         .memory(64 * 1024 * 1024)
         .storage(Engine::Large)
-        .with_device_config(
-            DirectFsDeviceOptionsBuilder::new(dir.path())
-                .with_capacity(256 * 1024 * 1024)
-                .build(),
-        )
+        .with_device_options(DirectFsDeviceOptions::new(dir.path()).with_capacity(256 * 1024 * 1024))
         .build()
         .await?;
 

--- a/foyer-bench/src/main.rs
+++ b/foyer-bench/src/main.rs
@@ -34,9 +34,9 @@ use analyze::{analyze, monitor, Metrics};
 use bytesize::ByteSize;
 use clap::{builder::PossibleValuesParser, ArgGroup, Parser};
 use foyer::{
-    Compression, DirectFileDeviceOptionsBuilder, DirectFsDeviceOptionsBuilder, Engine, FifoConfig, FifoPicker,
-    HybridCache, HybridCacheBuilder, InvalidRatioPicker, LargeEngineOptions, LfuConfig, LruConfig, RateLimitPicker,
-    RecoverMode, RuntimeConfig, S3FifoConfig, SmallEngineOptions, TokioRuntimeConfig, TracingConfig,
+    Compression, DirectFileDeviceOptions, DirectFsDeviceOptions, Engine, FifoConfig, FifoPicker, HybridCache,
+    HybridCacheBuilder, InvalidRatioPicker, LargeEngineOptions, LfuConfig, LruConfig, RateLimitPicker, RecoverMode,
+    RuntimeConfig, S3FifoConfig, SmallEngineOptions, TokioRuntimeConfig, TracingConfig,
 };
 use futures::future::join_all;
 use itertools::Itertools;
@@ -462,17 +462,15 @@ async fn benchmark(args: Args) {
         .storage(args.engine);
 
     builder = match (args.file.as_ref(), args.dir.as_ref()) {
-        (Some(file), None) => builder.with_device_config(
-            DirectFileDeviceOptionsBuilder::new(file)
+        (Some(file), None) => builder.with_device_options(
+            DirectFileDeviceOptions::new(file)
                 .with_capacity(args.disk.as_u64() as _)
-                .with_region_size(args.region_size.as_u64() as _)
-                .build(),
+                .with_region_size(args.region_size.as_u64() as _),
         ),
-        (None, Some(dir)) => builder.with_device_config(
-            DirectFsDeviceOptionsBuilder::new(dir)
+        (None, Some(dir)) => builder.with_device_options(
+            DirectFsDeviceOptions::new(dir)
                 .with_capacity(args.disk.as_u64() as _)
-                .with_file_size(args.region_size.as_u64() as _)
-                .build(),
+                .with_file_size(args.region_size.as_u64() as _),
         ),
         _ => unreachable!(),
     };

--- a/foyer-storage/src/device/direct_file.rs
+++ b/foyer-storage/src/device/direct_file.rs
@@ -22,7 +22,7 @@ use foyer_common::{asyncify::asyncify_with_runtime, bits};
 use fs4::free_space;
 use serde::{Deserialize, Serialize};
 
-use super::{Dev, DevConfig, DevExt, RegionId};
+use super::{Dev, DevExt, RegionId};
 use crate::{
     device::ALIGN,
     error::{Error, Result},
@@ -36,18 +36,7 @@ pub struct DirectFileDeviceConfig {
     region_size: usize,
 }
 
-/// A device that uses a single direct i/o file.
-#[derive(Debug, Clone)]
-pub struct DirectFileDevice {
-    file: Arc<File>,
-
-    capacity: usize,
-    region_size: usize,
-
-    runtime: Runtime,
-}
-
-impl DevConfig for DirectFileDeviceConfig {
+impl DirectFileDeviceConfig {
     fn verify(&self) -> Result<()> {
         if self.region_size == 0 || self.region_size % ALIGN != 0 {
             return Err(anyhow::anyhow!(
@@ -68,6 +57,17 @@ impl DevConfig for DirectFileDeviceConfig {
 
         Ok(())
     }
+}
+
+/// A device that uses a single direct i/o file.
+#[derive(Debug, Clone)]
+pub struct DirectFileDevice {
+    file: Arc<File>,
+
+    capacity: usize,
+    region_size: usize,
+
+    runtime: Runtime,
 }
 
 impl DirectFileDevice {

--- a/foyer-storage/src/device/direct_file.rs
+++ b/foyer-storage/src/device/direct_file.rs
@@ -29,15 +29,11 @@ use crate::{
     IoBytes, IoBytesMut, Runtime,
 };
 
-/// Options for the direct file device.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct DirectFileDeviceConfig {
-    /// Path of the direct file device.
-    pub path: PathBuf,
-    /// Capacity of the direct file device.
-    pub capacity: usize,
-    /// Region size of the direct file device.
-    pub region_size: usize,
+    path: PathBuf,
+    capacity: usize,
+    region_size: usize,
 }
 
 /// A device that uses a single direct i/o file.

--- a/foyer-storage/src/device/direct_fs.rs
+++ b/foyer-storage/src/device/direct_fs.rs
@@ -24,7 +24,7 @@ use futures::future::try_join_all;
 use itertools::Itertools;
 use serde::{Deserialize, Serialize};
 
-use super::{Dev, DevConfig, DevExt, RegionId};
+use super::{Dev, DevExt, RegionId};
 use crate::{
     device::ALIGN,
     error::{Error, Result},
@@ -38,23 +38,7 @@ pub struct DirectFsDeviceConfig {
     file_size: usize,
 }
 
-/// A device that uses direct i/o files in a directory of a file system.
-#[derive(Debug, Clone)]
-pub struct DirectFsDevice {
-    inner: Arc<DirectFsDeviceInner>,
-}
-
-#[derive(Debug)]
-struct DirectFsDeviceInner {
-    files: Vec<Arc<File>>,
-
-    capacity: usize,
-    file_size: usize,
-
-    runtime: Runtime,
-}
-
-impl DevConfig for DirectFsDeviceConfig {
+impl DirectFsDeviceConfig {
     fn verify(&self) -> Result<()> {
         if self.file_size == 0 || self.file_size % ALIGN != 0 {
             return Err(anyhow::anyhow!(
@@ -75,6 +59,22 @@ impl DevConfig for DirectFsDeviceConfig {
 
         Ok(())
     }
+}
+
+/// A device that uses direct i/o files in a directory of a file system.
+#[derive(Debug, Clone)]
+pub struct DirectFsDevice {
+    inner: Arc<DirectFsDeviceInner>,
+}
+
+#[derive(Debug)]
+struct DirectFsDeviceInner {
+    files: Vec<Arc<File>>,
+
+    capacity: usize,
+    file_size: usize,
+
+    runtime: Runtime,
 }
 
 impl DirectFsDevice {

--- a/foyer-storage/src/device/direct_fs.rs
+++ b/foyer-storage/src/device/direct_fs.rs
@@ -31,15 +31,11 @@ use crate::{
     IoBytes, IoBytesMut, Runtime,
 };
 
-/// Options for the direct fs device.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct DirectFsDeviceConfig {
-    /// Directory of the direct fs device.
-    pub dir: PathBuf,
-    /// Capacity of the direct fs device.
-    pub capacity: usize,
-    /// Direct i/o file size of the direct fs device.
-    pub file_size: usize,
+    dir: PathBuf,
+    capacity: usize,
+    file_size: usize,
 }
 
 /// A device that uses direct i/o files in a directory of a file system.

--- a/foyer-storage/src/device/mod.rs
+++ b/foyer-storage/src/device/mod.rs
@@ -24,8 +24,8 @@ use allocator::AlignedAllocator;
 use monitor::Monitored;
 
 use crate::{
-    error::Result, DirectFileDevice, DirectFileDeviceOptions, DirectFsDevice, DirectFsDeviceOptions, IoBytes,
-    IoBytesMut, Runtime,
+    error::Result, DirectFileDevice, DirectFileDeviceConfig, DirectFsDevice, DirectFsDeviceConfig, IoBytes, IoBytesMut,
+    Runtime,
 };
 
 pub const ALIGN: usize = 4096;
@@ -33,9 +33,9 @@ pub const IO_BUFFER_ALLOCATOR: AlignedAllocator<ALIGN> = AlignedAllocator::new()
 
 pub type RegionId = u32;
 
-/// Options for the device.
-pub trait DevOptions: Send + Sync + 'static + Debug + Clone {
-    /// Verify the correctness of the options.
+/// Config for the device.
+pub trait DevConfig: Send + Sync + 'static + Debug {
+    /// Verify the correctness of the config.
     fn verify(&self) -> Result<()>;
 }
 
@@ -43,8 +43,8 @@ pub trait DevOptions: Send + Sync + 'static + Debug + Clone {
 ///
 /// Both i/o block and i/o buffer must be aligned to 4K.
 pub trait Dev: Send + Sync + 'static + Sized + Clone + Debug {
-    /// Options for the device.
-    type Options: DevOptions;
+    /// Config for the device.
+    type Config: DevConfig;
 
     /// The capacity of the device, must be 4K aligned.
     fn capacity(&self) -> usize;
@@ -53,9 +53,9 @@ pub trait Dev: Send + Sync + 'static + Sized + Clone + Debug {
     fn region_size(&self) -> usize;
 
     // TODO(MrCroxx): Refactor the builder.
-    /// Open the device with the given options.
+    /// Open the device with the given config.
     #[must_use]
-    fn open(options: Self::Options, runtime: Runtime) -> impl Future<Output = Result<Self>> + Send;
+    fn open(config: Self::Config, runtime: Runtime) -> impl Future<Output = Result<Self>> + Send;
 
     /// Write API for the device.
     #[must_use]
@@ -86,28 +86,28 @@ pub trait DevExt: Dev {
 impl<T> DevExt for T where T: Dev {}
 
 #[derive(Debug, Clone)]
-pub enum DeviceOptions {
-    DirectFile(DirectFileDeviceOptions),
-    DirectFs(DirectFsDeviceOptions),
+pub enum DeviceConfig {
+    DirectFile(DirectFileDeviceConfig),
+    DirectFs(DirectFsDeviceConfig),
 }
 
-impl From<DirectFileDeviceOptions> for DeviceOptions {
-    fn from(value: DirectFileDeviceOptions) -> Self {
+impl From<DirectFileDeviceConfig> for DeviceConfig {
+    fn from(value: DirectFileDeviceConfig) -> Self {
         Self::DirectFile(value)
     }
 }
 
-impl From<DirectFsDeviceOptions> for DeviceOptions {
-    fn from(value: DirectFsDeviceOptions) -> Self {
+impl From<DirectFsDeviceConfig> for DeviceConfig {
+    fn from(value: DirectFsDeviceConfig) -> Self {
         Self::DirectFs(value)
     }
 }
 
-impl DevOptions for DeviceOptions {
+impl DevConfig for DeviceConfig {
     fn verify(&self) -> Result<()> {
         match self {
-            DeviceOptions::DirectFile(dev) => dev.verify(),
-            DeviceOptions::DirectFs(dev) => dev.verify(),
+            DeviceConfig::DirectFile(dev) => dev.verify(),
+            DeviceConfig::DirectFs(dev) => dev.verify(),
         }
     }
 }
@@ -119,7 +119,7 @@ pub enum Device {
 }
 
 impl Dev for Device {
-    type Options = DeviceOptions;
+    type Config = DeviceConfig;
 
     fn capacity(&self) -> usize {
         match self {
@@ -135,10 +135,10 @@ impl Dev for Device {
         }
     }
 
-    async fn open(options: Self::Options, runtime: Runtime) -> Result<Self> {
+    async fn open(options: Self::Config, runtime: Runtime) -> Result<Self> {
         match options {
-            DeviceOptions::DirectFile(opts) => Ok(Self::DirectFile(DirectFileDevice::open(opts, runtime).await?)),
-            DeviceOptions::DirectFs(opts) => Ok(Self::DirectFs(DirectFsDevice::open(opts, runtime).await?)),
+            DeviceConfig::DirectFile(opts) => Ok(Self::DirectFile(DirectFileDevice::open(opts, runtime).await?)),
+            DeviceConfig::DirectFs(opts) => Ok(Self::DirectFs(DirectFsDevice::open(opts, runtime).await?)),
         }
     }
 

--- a/foyer-storage/src/device/mod.rs
+++ b/foyer-storage/src/device/mod.rs
@@ -21,11 +21,13 @@ pub mod monitor;
 use std::{fmt::Debug, future::Future};
 
 use allocator::AlignedAllocator;
+use direct_file::DirectFileDeviceConfig;
+use direct_fs::DirectFsDeviceConfig;
 use monitor::Monitored;
 
 use crate::{
-    error::Result, DirectFileDevice, DirectFileDeviceConfig, DirectFsDevice, DirectFsDeviceConfig, IoBytes, IoBytesMut,
-    Runtime,
+    error::Result, DirectFileDevice, DirectFileDeviceOptions, DirectFsDevice, DirectFsDeviceOptions, IoBytes,
+    IoBytesMut, Runtime,
 };
 
 pub const ALIGN: usize = 4096;
@@ -91,15 +93,15 @@ pub enum DeviceConfig {
     DirectFs(DirectFsDeviceConfig),
 }
 
-impl From<DirectFileDeviceConfig> for DeviceConfig {
-    fn from(value: DirectFileDeviceConfig) -> Self {
-        Self::DirectFile(value)
+impl From<DirectFileDeviceOptions> for DeviceConfig {
+    fn from(options: DirectFileDeviceOptions) -> Self {
+        Self::DirectFile(options.into())
     }
 }
 
-impl From<DirectFsDeviceConfig> for DeviceConfig {
-    fn from(value: DirectFsDeviceConfig) -> Self {
-        Self::DirectFs(value)
+impl From<DirectFsDeviceOptions> for DeviceConfig {
+    fn from(options: DirectFsDeviceOptions) -> Self {
+        Self::DirectFs(options.into())
     }
 }
 

--- a/foyer-storage/src/device/mod.rs
+++ b/foyer-storage/src/device/mod.rs
@@ -36,10 +36,8 @@ pub const IO_BUFFER_ALLOCATOR: AlignedAllocator<ALIGN> = AlignedAllocator::new()
 pub type RegionId = u32;
 
 /// Config for the device.
-pub trait DevConfig: Send + Sync + 'static + Debug {
-    /// Verify the correctness of the config.
-    fn verify(&self) -> Result<()>;
-}
+pub trait DevConfig: Send + Sync + 'static + Debug {}
+impl<T: Send + Sync + 'static + Debug> DevConfig for T {}
 
 /// [`Dev`] represents 4K aligned block device.
 ///
@@ -102,15 +100,6 @@ impl From<DirectFileDeviceOptions> for DeviceConfig {
 impl From<DirectFsDeviceOptions> for DeviceConfig {
     fn from(options: DirectFsDeviceOptions) -> Self {
         Self::DirectFs(options.into())
-    }
-}
-
-impl DevConfig for DeviceConfig {
-    fn verify(&self) -> Result<()> {
-        match self {
-            DeviceConfig::DirectFile(dev) => dev.verify(),
-            DeviceConfig::DirectFs(dev) => dev.verify(),
-        }
     }
 }
 

--- a/foyer-storage/src/device/monitor.rs
+++ b/foyer-storage/src/device/monitor.rs
@@ -24,7 +24,7 @@ use std::{
 use foyer_common::{bits, metrics::Metrics};
 
 use super::RegionId;
-use crate::{error::Result, Dev, DevConfig, DevExt, DirectFileDevice, IoBytes, IoBytesMut, Runtime};
+use crate::{error::Result, Dev, DevExt, DirectFileDevice, IoBytes, IoBytesMut, Runtime};
 
 /// The statistics information of the device.
 #[derive(Debug, Default)]
@@ -61,15 +61,6 @@ where
             .field("options", &self.config)
             .field("metrics", &self.metrics)
             .finish()
-    }
-}
-
-impl<D> DevConfig for MonitoredConfig<D>
-where
-    D: Dev,
-{
-    fn verify(&self) -> Result<()> {
-        self.config.verify()
     }
 }
 

--- a/foyer-storage/src/device/monitor.rs
+++ b/foyer-storage/src/device/monitor.rs
@@ -48,7 +48,7 @@ pub struct MonitoredConfig<D>
 where
     D: Dev,
 {
-    pub options: D::Config,
+    pub config: D::Config,
     pub metrics: Arc<Metrics>,
 }
 
@@ -58,7 +58,7 @@ where
 {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         f.debug_struct("MonitoredOptions")
-            .field("options", &self.options)
+            .field("options", &self.config)
             .field("metrics", &self.metrics)
             .finish()
     }
@@ -69,7 +69,7 @@ where
     D: Dev,
 {
     fn verify(&self) -> Result<()> {
-        self.options.verify()
+        self.config.verify()
     }
 }
 
@@ -88,7 +88,7 @@ where
     D: Dev,
 {
     async fn open(options: MonitoredConfig<D>, runtime: Runtime) -> Result<Self> {
-        let device = D::open(options.options, runtime).await?;
+        let device = D::open(options.config, runtime).await?;
         Ok(Self {
             device,
             stats: Arc::default(),

--- a/foyer-storage/src/device/monitor.rs
+++ b/foyer-storage/src/device/monitor.rs
@@ -24,7 +24,7 @@ use std::{
 use foyer_common::{bits, metrics::Metrics};
 
 use super::RegionId;
-use crate::{error::Result, Dev, DevExt, DevOptions, DirectFileDevice, IoBytes, IoBytesMut, Runtime};
+use crate::{error::Result, Dev, DevConfig, DevExt, DirectFileDevice, IoBytes, IoBytesMut, Runtime};
 
 /// The statistics information of the device.
 #[derive(Debug, Default)]
@@ -44,15 +44,15 @@ pub struct DeviceStats {
 }
 
 #[derive(Clone)]
-pub struct MonitoredOptions<D>
+pub struct MonitoredConfig<D>
 where
     D: Dev,
 {
-    pub options: D::Options,
+    pub options: D::Config,
     pub metrics: Arc<Metrics>,
 }
 
-impl<D> Debug for MonitoredOptions<D>
+impl<D> Debug for MonitoredConfig<D>
 where
     D: Dev,
 {
@@ -64,7 +64,7 @@ where
     }
 }
 
-impl<D> DevOptions for MonitoredOptions<D>
+impl<D> DevConfig for MonitoredConfig<D>
 where
     D: Dev,
 {
@@ -87,7 +87,7 @@ impl<D> Monitored<D>
 where
     D: Dev,
 {
-    async fn open(options: MonitoredOptions<D>, runtime: Runtime) -> Result<Self> {
+    async fn open(options: MonitoredConfig<D>, runtime: Runtime) -> Result<Self> {
         let device = D::open(options.options, runtime).await?;
         Ok(Self {
             device,
@@ -149,7 +149,7 @@ impl<D> Dev for Monitored<D>
 where
     D: Dev,
 {
-    type Options = MonitoredOptions<D>;
+    type Config = MonitoredConfig<D>;
 
     fn capacity(&self) -> usize {
         self.device.capacity()
@@ -159,8 +159,8 @@ where
         self.device.region_size()
     }
 
-    async fn open(options: Self::Options, runtime: Runtime) -> Result<Self> {
-        Self::open(options, runtime).await
+    async fn open(config: Self::Config, runtime: Runtime) -> Result<Self> {
+        Self::open(config, runtime).await
     }
 
     async fn write(&self, buf: IoBytes, region: RegionId, offset: u64) -> Result<()> {

--- a/foyer-storage/src/large/generic.rs
+++ b/foyer-storage/src/large/generic.rs
@@ -495,8 +495,8 @@ mod tests {
     use super::*;
     use crate::{
         device::{
-            direct_fs::DirectFsDeviceOptions,
-            monitor::{Monitored, MonitoredOptions},
+            direct_fs::DirectFsDeviceConfig,
+            monitor::{Monitored, MonitoredConfig},
         },
         picker::utils::{FifoPicker, RejectAllPicker},
         serde::EntrySerializer,
@@ -515,8 +515,8 @@ mod tests {
     async fn device_for_test(dir: impl AsRef<Path>) -> MonitoredDevice {
         let runtime = Runtime::current();
         Monitored::open(
-            MonitoredOptions {
-                options: DirectFsDeviceOptions {
+            MonitoredConfig {
+                options: DirectFsDeviceConfig {
                     dir: dir.as_ref().into(),
                     capacity: 64 * KB,
                     file_size: 16 * KB,

--- a/foyer-storage/src/large/generic.rs
+++ b/foyer-storage/src/large/generic.rs
@@ -488,20 +488,18 @@ mod tests {
     use std::{fs::File, path::Path};
 
     use ahash::RandomState;
+    use bytesize::ByteSize;
     use foyer_memory::{Cache, CacheBuilder, FifoConfig};
     use itertools::Itertools;
     use tokio::runtime::Handle;
 
     use super::*;
     use crate::{
-        device::{
-            direct_fs::DirectFsDeviceConfig,
-            monitor::{Monitored, MonitoredConfig},
-        },
+        device::monitor::{Monitored, MonitoredConfig},
         picker::utils::{FifoPicker, RejectAllPicker},
         serde::EntrySerializer,
         test_utils::BiasedPicker,
-        TombstoneLogConfigBuilder,
+        DirectFsDeviceOptions, TombstoneLogConfigBuilder,
     };
 
     const KB: usize = 1024;
@@ -516,12 +514,10 @@ mod tests {
         let runtime = Runtime::current();
         Monitored::open(
             MonitoredConfig {
-                options: DirectFsDeviceConfig {
-                    dir: dir.as_ref().into(),
-                    capacity: 64 * KB,
-                    file_size: 16 * KB,
-                }
-                .into(),
+                config: DirectFsDeviceOptions::new(dir)
+                    .with_capacity(ByteSize::kib(64).as_u64() as _)
+                    .with_file_size(ByteSize::kib(16).as_u64() as _)
+                    .into(),
                 metrics: Arc::new(Metrics::new("test")),
             },
             runtime,

--- a/foyer-storage/src/large/scanner.rs
+++ b/foyer-storage/src/large/scanner.rs
@@ -244,11 +244,11 @@ mod tests {
     use super::*;
     use crate::{
         device::{
-            monitor::{Monitored, MonitoredOptions},
+            monitor::{Monitored, MonitoredConfig},
             Dev, MonitoredDevice,
         },
         region::RegionStats,
-        DirectFsDeviceOptions, Runtime,
+        DirectFsDeviceConfig, Runtime,
     };
 
     const KB: usize = 1024;
@@ -256,8 +256,8 @@ mod tests {
     async fn device_for_test(dir: impl AsRef<Path>) -> MonitoredDevice {
         let runtime = Runtime::current();
         Monitored::open(
-            MonitoredOptions {
-                options: DirectFsDeviceOptions {
+            MonitoredConfig {
+                options: DirectFsDeviceConfig {
                     dir: dir.as_ref().into(),
                     capacity: 64 * KB,
                     file_size: 16 * KB,

--- a/foyer-storage/src/large/scanner.rs
+++ b/foyer-storage/src/large/scanner.rs
@@ -241,6 +241,8 @@ impl RegionScanner {
 mod tests {
     use std::path::Path;
 
+    use bytesize::ByteSize;
+
     use super::*;
     use crate::{
         device::{
@@ -248,21 +250,17 @@ mod tests {
             Dev, MonitoredDevice,
         },
         region::RegionStats,
-        DirectFsDeviceConfig, Runtime,
+        DirectFsDeviceOptions, Runtime,
     };
-
-    const KB: usize = 1024;
 
     async fn device_for_test(dir: impl AsRef<Path>) -> MonitoredDevice {
         let runtime = Runtime::current();
         Monitored::open(
             MonitoredConfig {
-                options: DirectFsDeviceConfig {
-                    dir: dir.as_ref().into(),
-                    capacity: 64 * KB,
-                    file_size: 16 * KB,
-                }
-                .into(),
+                config: DirectFsDeviceOptions::new(dir)
+                    .with_capacity(ByteSize::kib(64).as_u64() as _)
+                    .with_file_size(ByteSize::kib(16).as_u64() as _)
+                    .into(),
                 metrics: Arc::new(Metrics::new("test")),
             },
             runtime,

--- a/foyer-storage/src/large/tombstone.rs
+++ b/foyer-storage/src/large/tombstone.rs
@@ -25,12 +25,12 @@ use tokio::sync::Mutex;
 
 use crate::{
     device::{
-        direct_file::{DirectFileDevice, DirectFileDeviceOptionsBuilder},
-        monitor::{Monitored, MonitoredOptions},
+        direct_file::DirectFileDevice,
+        monitor::{Monitored, MonitoredConfig},
         Dev, DevExt, RegionId,
     },
     error::{Error, Result},
-    IoBytesMut, Runtime,
+    DirectFileDeviceOptions, IoBytesMut, Runtime,
 };
 
 /// The configurations for the tombstone log.
@@ -136,11 +136,11 @@ impl TombstoneLog {
         let capacity = bits::align_up(align, (cache_device.capacity() / align) * Tombstone::serialized_len());
 
         let device = Monitored::open(
-            MonitoredOptions {
-                options: DirectFileDeviceOptionsBuilder::new(path)
+            MonitoredConfig {
+                options: DirectFileDeviceOptions::new(path)
                     .with_region_size(align)
                     .with_capacity(capacity)
-                    .build(),
+                    .into(),
                 metrics,
             },
             runtime,
@@ -312,7 +312,7 @@ mod tests {
     use tempfile::tempdir;
 
     use super::*;
-    use crate::device::direct_fs::{DirectFsDevice, DirectFsDeviceOptionsBuilder};
+    use crate::device::direct_fs::{DirectFsDevice, DirectFsDeviceOptions};
 
     #[test_log::test(tokio::test)]
     async fn test_tombstone_log() {
@@ -322,9 +322,9 @@ mod tests {
 
         // 4 MB cache device => 16 KB tombstone log => 1K tombstones
         let device = DirectFsDevice::open(
-            DirectFsDeviceOptionsBuilder::new(dir.path())
+            DirectFsDeviceOptions::new(dir.path())
                 .with_capacity(4 * 1024 * 1024)
-                .build(),
+                .into(),
             runtime.clone(),
         )
         .await

--- a/foyer-storage/src/large/tombstone.rs
+++ b/foyer-storage/src/large/tombstone.rs
@@ -137,7 +137,7 @@ impl TombstoneLog {
 
         let device = Monitored::open(
             MonitoredConfig {
-                options: DirectFileDeviceOptions::new(path)
+                config: DirectFileDeviceOptions::new(path)
                     .with_region_size(align)
                     .with_capacity(capacity)
                     .into(),

--- a/foyer-storage/src/prelude.rs
+++ b/foyer-storage/src/prelude.rs
@@ -16,8 +16,8 @@ pub use crate::{
     compress::Compression,
     device::{
         bytes::{IoBuffer, IoBytes, IoBytesMut},
-        direct_file::{DirectFileDevice, DirectFileDeviceConfig, DirectFileDeviceOptions},
-        direct_fs::{DirectFsDevice, DirectFsDeviceConfig, DirectFsDeviceOptions},
+        direct_file::{DirectFileDevice, DirectFileDeviceOptions},
+        direct_fs::{DirectFsDevice, DirectFsDeviceOptions},
         monitor::DeviceStats,
         Dev, DevConfig, DevExt,
     },
@@ -34,7 +34,7 @@ pub use crate::{
     statistics::Statistics,
     storage::{either::Order, Storage},
     store::{
-        DeviceOptionsEnum, Engine, LargeEngineOptions, RuntimeConfig, SmallEngineOptions, Store, StoreBuilder,
+        DeviceOptions, Engine, LargeEngineOptions, RuntimeConfig, SmallEngineOptions, Store, StoreBuilder,
         TokioRuntimeConfig,
     },
 };

--- a/foyer-storage/src/prelude.rs
+++ b/foyer-storage/src/prelude.rs
@@ -16,10 +16,10 @@ pub use crate::{
     compress::Compression,
     device::{
         bytes::{IoBuffer, IoBytes, IoBytesMut},
-        direct_file::{DirectFileDevice, DirectFileDeviceOptions, DirectFileDeviceOptionsBuilder},
-        direct_fs::{DirectFsDevice, DirectFsDeviceOptions, DirectFsDeviceOptionsBuilder},
+        direct_file::{DirectFileDevice, DirectFileDeviceConfig, DirectFileDeviceOptions},
+        direct_fs::{DirectFsDevice, DirectFsDeviceConfig, DirectFsDeviceOptions},
         monitor::DeviceStats,
-        Dev, DevExt, DevOptions,
+        Dev, DevConfig, DevExt,
     },
     error::{Error, Result},
     large::{
@@ -34,7 +34,7 @@ pub use crate::{
     statistics::Statistics,
     storage::{either::Order, Storage},
     store::{
-        DeviceConfig, Engine, LargeEngineOptions, RuntimeConfig, SmallEngineOptions, Store, StoreBuilder,
+        DeviceOptionsEnum, Engine, LargeEngineOptions, RuntimeConfig, SmallEngineOptions, Store, StoreBuilder,
         TokioRuntimeConfig,
     },
 };

--- a/foyer-storage/src/small/generic.rs
+++ b/foyer-storage/src/small/generic.rs
@@ -311,7 +311,7 @@ mod tests {
             Dev,
         },
         serde::EntrySerializer,
-        DevExt, DirectFsDeviceConfig,
+        DevExt, DirectFsDeviceOptions,
     };
 
     fn cache_for_test() -> Cache<u64, Vec<u8>> {
@@ -324,12 +324,10 @@ mod tests {
         let runtime = Runtime::current();
         Monitored::open(
             MonitoredConfig {
-                options: DirectFsDeviceConfig {
-                    dir: dir.as_ref().into(),
-                    capacity: ByteSize::kib(64).as_u64() as _,
-                    file_size: ByteSize::kib(16).as_u64() as _,
-                }
-                .into(),
+                config: DirectFsDeviceOptions::new(dir)
+                    .with_capacity(ByteSize::kib(64).as_u64() as _)
+                    .with_file_size(ByteSize::kib(16).as_u64() as _)
+                    .into(),
                 metrics: Arc::new(Metrics::new("test")),
             },
             runtime,

--- a/foyer-storage/src/small/generic.rs
+++ b/foyer-storage/src/small/generic.rs
@@ -307,11 +307,11 @@ mod tests {
     use super::*;
     use crate::{
         device::{
-            monitor::{Monitored, MonitoredOptions},
+            monitor::{Monitored, MonitoredConfig},
             Dev,
         },
         serde::EntrySerializer,
-        DevExt, DirectFsDeviceOptions,
+        DevExt, DirectFsDeviceConfig,
     };
 
     fn cache_for_test() -> Cache<u64, Vec<u8>> {
@@ -323,8 +323,8 @@ mod tests {
     async fn device_for_test(dir: impl AsRef<Path>) -> MonitoredDevice {
         let runtime = Runtime::current();
         Monitored::open(
-            MonitoredOptions {
-                options: DirectFsDeviceOptions {
+            MonitoredConfig {
+                options: DirectFsDeviceConfig {
                     dir: dir.as_ref().into(),
                     capacity: ByteSize::kib(64).as_u64() as _,
                     file_size: ByteSize::kib(16).as_u64() as _,

--- a/foyer-storage/tests/storage_test.rs
+++ b/foyer-storage/tests/storage_test.rs
@@ -19,7 +19,7 @@ use std::{path::Path, sync::Arc, time::Duration};
 use ahash::RandomState;
 use foyer_memory::{Cache, CacheBuilder, CacheEntry, FifoConfig};
 use foyer_storage::{
-    test_utils::Recorder, Compression, DirectFsDeviceOptionsBuilder, Engine, LargeEngineOptions, StoreBuilder,
+    test_utils::Recorder, Compression, DirectFsDeviceOptions, Engine, LargeEngineOptions, StoreBuilder,
 };
 
 const KB: usize = 1024;
@@ -110,11 +110,10 @@ fn basic(
 ) -> StoreBuilder<u64, Vec<u8>> {
     // TODO(MrCroxx): Test mixed engine here.
     StoreBuilder::new(memory.clone(), Engine::Large)
-        .with_device_config(
-            DirectFsDeviceOptionsBuilder::new(path)
+        .with_device_options(
+            DirectFsDeviceOptions::new(path)
                 .with_capacity(4 * MB)
-                .with_file_size(MB)
-                .build(),
+                .with_file_size(MB),
         )
         .with_admission_picker(recorder.clone())
         .with_flush(true)

--- a/foyer/src/hybrid/builder.rs
+++ b/foyer/src/hybrid/builder.rs
@@ -22,7 +22,7 @@ use foyer_common::{
 };
 use foyer_memory::{Cache, CacheBuilder, EvictionConfig, Weighter};
 use foyer_storage::{
-    AdmissionPicker, Compression, DeviceConfig, Engine, LargeEngineOptions, RecoverMode, RuntimeConfig,
+    AdmissionPicker, Compression, DeviceOptionsEnum, Engine, LargeEngineOptions, RecoverMode, RuntimeConfig,
     SmallEngineOptions, StoreBuilder,
 };
 
@@ -204,9 +204,9 @@ where
     V: StorageValue,
     S: HashBuilder + Debug,
 {
-    /// Set device config for the disk cache store.
-    pub fn with_device_config(self, device_config: impl Into<DeviceConfig>) -> Self {
-        let builder = self.builder.with_device_config(device_config);
+    /// Set device options for the disk cache store.
+    pub fn with_device_options(self, device_options: impl Into<DeviceOptionsEnum>) -> Self {
+        let builder = self.builder.with_device_options(device_options);
         Self {
             name: self.name,
             tracing_config: self.tracing_config,

--- a/foyer/src/hybrid/builder.rs
+++ b/foyer/src/hybrid/builder.rs
@@ -22,7 +22,7 @@ use foyer_common::{
 };
 use foyer_memory::{Cache, CacheBuilder, EvictionConfig, Weighter};
 use foyer_storage::{
-    AdmissionPicker, Compression, DeviceOptionsEnum, Engine, LargeEngineOptions, RecoverMode, RuntimeConfig,
+    AdmissionPicker, Compression, DeviceOptions, Engine, LargeEngineOptions, RecoverMode, RuntimeConfig,
     SmallEngineOptions, StoreBuilder,
 };
 
@@ -205,7 +205,7 @@ where
     S: HashBuilder + Debug,
 {
     /// Set device options for the disk cache store.
-    pub fn with_device_options(self, device_options: impl Into<DeviceOptionsEnum>) -> Self {
+    pub fn with_device_options(self, device_options: impl Into<DeviceOptions>) -> Self {
         let builder = self.builder.with_device_options(device_options);
         Self {
             name: self.name,

--- a/foyer/src/hybrid/cache.rs
+++ b/foyer/src/hybrid/cache.rs
@@ -551,11 +551,10 @@ mod tests {
             .memory(4 * MB)
             // TODO(MrCroxx): Test with `Engine::Mixed`.
             .storage(Engine::Large)
-            .with_device_config(
-                DirectFsDeviceOptionsBuilder::new(dir)
+            .with_device_options(
+                DirectFsDeviceOptions::new(dir)
                     .with_capacity(16 * MB)
-                    .with_file_size(MB)
-                    .build(),
+                    .with_file_size(MB),
             )
             .build()
             .await
@@ -575,11 +574,10 @@ mod tests {
             .memory(4 * MB)
             // TODO(MrCroxx): Test with `Engine::Mixed`.
             .storage(Engine::Large)
-            .with_device_config(
-                DirectFsDeviceOptionsBuilder::new(dir)
+            .with_device_options(
+                DirectFsDeviceOptions::new(dir)
                     .with_capacity(16 * MB)
-                    .with_file_size(MB)
-                    .build(),
+                    .with_file_size(MB),
             )
             .with_admission_picker(Arc::new(BiasedPicker::new(admits)))
             .build()

--- a/foyer/src/prelude.rs
+++ b/foyer/src/prelude.rs
@@ -25,10 +25,9 @@ pub use memory::{
 };
 pub use storage::{
     AdmissionPicker, AdmitAllPicker, Compression, Dev, DevConfig, DevExt, DeviceStats, DirectFileDevice,
-    DirectFileDeviceConfig, DirectFileDeviceOptions, DirectFsDevice, DirectFsDeviceConfig, DirectFsDeviceOptions,
-    Engine, EvictionPicker, FifoPicker, InvalidRatioPicker, LargeEngineOptions, RateLimitPicker, RecoverMode,
-    ReinsertionPicker, RejectAllPicker, Runtime, RuntimeConfig, SmallEngineOptions, Storage, Store, StoreBuilder,
-    TokioRuntimeConfig, TombstoneLogConfigBuilder,
+    DirectFileDeviceOptions, DirectFsDevice, DirectFsDeviceOptions, Engine, EvictionPicker, FifoPicker,
+    InvalidRatioPicker, LargeEngineOptions, RateLimitPicker, RecoverMode, ReinsertionPicker, RejectAllPicker, Runtime,
+    RuntimeConfig, SmallEngineOptions, Storage, Store, StoreBuilder, TokioRuntimeConfig, TombstoneLogConfigBuilder,
 };
 
 pub use crate::hybrid::{

--- a/foyer/src/prelude.rs
+++ b/foyer/src/prelude.rs
@@ -24,11 +24,11 @@ pub use memory::{
     S3FifoConfig, Weighter,
 };
 pub use storage::{
-    AdmissionPicker, AdmitAllPicker, Compression, Dev, DevExt, DevOptions, DeviceStats, DirectFileDevice,
-    DirectFileDeviceOptions, DirectFileDeviceOptionsBuilder, DirectFsDevice, DirectFsDeviceOptions,
-    DirectFsDeviceOptionsBuilder, Engine, EvictionPicker, FifoPicker, InvalidRatioPicker, LargeEngineOptions,
-    RateLimitPicker, RecoverMode, ReinsertionPicker, RejectAllPicker, Runtime, RuntimeConfig, SmallEngineOptions,
-    Storage, Store, StoreBuilder, TokioRuntimeConfig, TombstoneLogConfigBuilder,
+    AdmissionPicker, AdmitAllPicker, Compression, Dev, DevConfig, DevExt, DeviceStats, DirectFileDevice,
+    DirectFileDeviceConfig, DirectFileDeviceOptions, DirectFsDevice, DirectFsDeviceConfig, DirectFsDeviceOptions,
+    Engine, EvictionPicker, FifoPicker, InvalidRatioPicker, LargeEngineOptions, RateLimitPicker, RecoverMode,
+    ReinsertionPicker, RejectAllPicker, Runtime, RuntimeConfig, SmallEngineOptions, Storage, Store, StoreBuilder,
+    TokioRuntimeConfig, TombstoneLogConfigBuilder,
 };
 
 pub use crate::hybrid::{


### PR DESCRIPTION
## What's changed and what's your intention?

> Please explain **IN DETAIL** what the changes are in this PR and why they are needed. :D

Make sure can use `XxxDeviceOptions` directly with `with_device_options()`. The old builder looks so wired.

## Checklist

- [x] I have written the necessary rustdoc comments
- [x] I have added the necessary unit tests and integration tests
- [x] I have passed `make all` (or `make fast` instead if the old tests are not modified) in my local environment.

## Related issues or PRs (optional)
#327 