### PR TITLE
refactor: refine runtime and tracing options

### DIFF
--- a/examples/hybrid_full.rs
+++ b/examples/hybrid_full.rs
@@ -18,7 +18,7 @@ use anyhow::Result;
 use chrono::Datelike;
 use foyer::{
     DirectFsDeviceOptions, Engine, FifoPicker, HybridCache, HybridCacheBuilder, LargeEngineOptions, LruConfig,
-    RateLimitPicker, RecoverMode, RuntimeConfig, SmallEngineOptions, TokioRuntimeConfig, TombstoneLogConfigBuilder,
+    RateLimitPicker, RecoverMode, RuntimeOptions, SmallEngineOptions, TokioRuntimeOptions, TombstoneLogConfigBuilder,
 };
 use tempfile::tempdir;
 
@@ -45,12 +45,12 @@ async fn main() -> Result<()> {
         .with_recover_mode(RecoverMode::Quiet)
         .with_admission_picker(Arc::new(RateLimitPicker::new(100 * 1024 * 1024)))
         .with_compression(foyer::Compression::Lz4)
-        .with_runtime_config(RuntimeConfig::Separated {
-            read_runtime_config: TokioRuntimeConfig {
+        .with_runtime_config(RuntimeOptions::Separated {
+            read_runtime_options: TokioRuntimeOptions {
                 worker_threads: 4,
                 max_blocking_threads: 8,
             },
-            write_runtime_config: TokioRuntimeConfig {
+            write_runtime_options: TokioRuntimeOptions {
                 worker_threads: 4,
                 max_blocking_threads: 8,
             },

--- a/examples/hybrid_full.rs
+++ b/examples/hybrid_full.rs
@@ -45,7 +45,7 @@ async fn main() -> Result<()> {
         .with_recover_mode(RecoverMode::Quiet)
         .with_admission_picker(Arc::new(RateLimitPicker::new(100 * 1024 * 1024)))
         .with_compression(foyer::Compression::Lz4)
-        .with_runtime_config(RuntimeOptions::Separated {
+        .with_runtime_options(RuntimeOptions::Separated {
             read_runtime_options: TokioRuntimeOptions {
                 worker_threads: 4,
                 max_blocking_threads: 8,

--- a/examples/tail_based_tracing.rs
+++ b/examples/tail_based_tracing.rs
@@ -14,7 +14,7 @@
 
 use std::time::Duration;
 
-use foyer::{DirectFsDeviceOptions, Engine, HybridCache, HybridCacheBuilder};
+use foyer::{DirectFsDeviceOptions, Engine, HybridCache, HybridCacheBuilder, TracingOptions};
 
 #[cfg(feature = "jaeger")]
 fn init_jaeger_exporter() {
@@ -76,9 +76,7 @@ async fn main() -> anyhow::Result<()> {
         .await?;
 
     hybrid.enable_tracing();
-    hybrid
-        .tracing_config()
-        .set_record_hybrid_get_threshold(Duration::from_millis(10));
+    hybrid.update_tracing_options(TracingOptions::new().with_record_hybrid_get_threshold(Duration::from_millis(10)));
 
     hybrid.insert(42, "The answer to life, the universe, and everything.".to_string());
     assert_eq!(

--- a/foyer-bench/Cargo.toml
+++ b/foyer-bench/Cargo.toml
@@ -22,6 +22,7 @@ fastrace-jaeger = { workspace = true, optional = true }
 foyer = { workspace = true }
 futures = "0.3"
 hdrhistogram = "7"
+humantime = "2"
 itertools = { workspace = true }
 metrics = { workspace = true }
 metrics-exporter-prometheus = "0.15"

--- a/foyer-bench/src/main.rs
+++ b/foyer-bench/src/main.rs
@@ -479,7 +479,7 @@ async fn benchmark(args: Args) {
         .with_flush(args.flush)
         .with_recover_mode(args.recover_mode)
         .with_compression(args.compression)
-        .with_runtime_config(match args.runtime.as_str() {
+        .with_runtime_options(match args.runtime.as_str() {
             "disabled" => RuntimeOptions::Disabled,
             "unified" => RuntimeOptions::Unified(TokioRuntimeOptions {
                 worker_threads: args.runtime_worker_threads,

--- a/foyer-storage/src/prelude.rs
+++ b/foyer-storage/src/prelude.rs
@@ -34,7 +34,7 @@ pub use crate::{
     statistics::Statistics,
     storage::{either::Order, Storage},
     store::{
-        DeviceOptions, Engine, LargeEngineOptions, RuntimeConfig, SmallEngineOptions, Store, StoreBuilder,
-        TokioRuntimeConfig,
+        DeviceOptions, Engine, LargeEngineOptions, RuntimeOptions, SmallEngineOptions, Store, StoreBuilder,
+        TokioRuntimeOptions,
     },
 };

--- a/foyer-storage/src/store.rs
+++ b/foyer-storage/src/store.rs
@@ -443,8 +443,8 @@ where
     }
 
     /// Configure the dedicated runtime for the disk cache store.
-    pub fn with_runtime_config(mut self, runtime_config: RuntimeOptions) -> Self {
-        self.runtime_config = runtime_config;
+    pub fn with_runtime_options(mut self, runtime_options: RuntimeOptions) -> Self {
+        self.runtime_config = runtime_options;
         self
     }
 

--- a/foyer/src/hybrid/builder.rs
+++ b/foyer/src/hybrid/builder.rs
@@ -272,8 +272,8 @@ where
     }
 
     /// Configure the dedicated runtime for the disk cache store.
-    pub fn with_runtime_config(self, runtime_config: RuntimeOptions) -> Self {
-        let builder = self.builder.with_runtime_config(runtime_config);
+    pub fn with_runtime_options(self, runtime_options: RuntimeOptions) -> Self {
+        let builder = self.builder.with_runtime_options(runtime_options);
         Self {
             name: self.name,
             tracing_options: self.tracing_options,

--- a/foyer/src/hybrid/cache.rs
+++ b/foyer/src/hybrid/cache.rs
@@ -33,7 +33,7 @@ use foyer_common::{
     code::{HashBuilder, StorageKey, StorageValue},
     future::Diversion,
     metrics::Metrics,
-    tracing::{InRootSpan, TracingConfig},
+    tracing::{InRootSpan, TracingConfig, TracingOptions},
 };
 use foyer_memory::{Cache, CacheContext, CacheEntry, Fetch, FetchMark, FetchState};
 use foyer_storage::{DeviceStats, Store};
@@ -130,23 +130,24 @@ where
         name: String,
         memory: Cache<K, V, S>,
         storage: Store<K, V, S>,
-        tracing_config: TracingConfig,
+        tracing_options: TracingOptions,
     ) -> Self {
         let metrics = Arc::new(Metrics::new(&name));
-        let tracing_config = Arc::new(tracing_config);
-        let trace = Arc::new(AtomicBool::new(false));
+        let tracing_config = Arc::<TracingConfig>::default();
+        tracing_config.update(tracing_options);
+        let tracing = Arc::new(AtomicBool::new(false));
         Self {
             memory,
             storage,
             metrics,
             tracing_config,
-            tracing: trace,
+            tracing,
         }
     }
 
-    /// Access the trace config.
-    pub fn tracing_config(&self) -> &TracingConfig {
-        &self.tracing_config
+    /// Access the trace config with options.
+    pub fn update_tracing_options(&self, options: TracingOptions) {
+        self.tracing_config.update(options);
     }
 
     /// Access the in-memory cache.

--- a/foyer/src/prelude.rs
+++ b/foyer/src/prelude.rs
@@ -17,7 +17,7 @@ pub use common::{
     code::{Key, StorageKey, StorageValue, Value},
     event::EventListener,
     range::RangeBoundsExt,
-    tracing::TracingConfig,
+    tracing::TracingOptions,
 };
 pub use memory::{
     Cache, CacheBuilder, CacheContext, CacheEntry, EvictionConfig, FetchState, FifoConfig, LfuConfig, LruConfig,
@@ -27,7 +27,7 @@ pub use storage::{
     AdmissionPicker, AdmitAllPicker, Compression, Dev, DevConfig, DevExt, DeviceStats, DirectFileDevice,
     DirectFileDeviceOptions, DirectFsDevice, DirectFsDeviceOptions, Engine, EvictionPicker, FifoPicker,
     InvalidRatioPicker, LargeEngineOptions, RateLimitPicker, RecoverMode, ReinsertionPicker, RejectAllPicker, Runtime,
-    RuntimeConfig, SmallEngineOptions, Storage, Store, StoreBuilder, TokioRuntimeConfig, TombstoneLogConfigBuilder,
+    RuntimeOptions, SmallEngineOptions, Storage, Store, StoreBuilder, TokioRuntimeOptions, TombstoneLogConfigBuilder,
 };
 
 pub use crate::hybrid::{

--- a/foyer/src/prelude.rs
+++ b/foyer/src/prelude.rs
@@ -12,26 +12,28 @@
 //  See the License for the specific language governing permissions and
 //  limitations under the License.
 
-pub use crate::common::{
-    buf::{BufExt, BufMutExt},
-    code::{Key, StorageKey, StorageValue, Value},
-    event::EventListener,
-    range::RangeBoundsExt,
-    tracing::TracingOptions,
-};
-pub use crate::memory::{
-    Cache, CacheBuilder, CacheContext, CacheEntry, EvictionConfig, FetchState, FifoConfig, LfuConfig, LruConfig,
-    S3FifoConfig, Weighter,
-};
-pub use crate::storage::{
-    AdmissionPicker, AdmitAllPicker, Compression, Dev, DevConfig, DevExt, DeviceStats, DirectFileDevice,
-    DirectFileDeviceOptions, DirectFsDevice, DirectFsDeviceOptions, Engine, EvictionPicker, FifoPicker,
-    InvalidRatioPicker, LargeEngineOptions, RateLimitPicker, RecoverMode, ReinsertionPicker, RejectAllPicker, Runtime,
-    RuntimeOptions, SmallEngineOptions, Storage, Store, StoreBuilder, TokioRuntimeOptions, TombstoneLogConfigBuilder,
-};
-
-pub use crate::hybrid::{
-    builder::{HybridCacheBuilder, HybridCacheBuilderPhaseMemory, HybridCacheBuilderPhaseStorage},
-    cache::{HybridCache, HybridCacheEntry, HybridFetch, HybridFetchInner},
-    writer::{HybridCacheStorageWriter, HybridCacheWriter},
+pub use crate::{
+    common::{
+        buf::{BufExt, BufMutExt},
+        code::{Key, StorageKey, StorageValue, Value},
+        event::EventListener,
+        range::RangeBoundsExt,
+        tracing::TracingOptions,
+    },
+    hybrid::{
+        builder::{HybridCacheBuilder, HybridCacheBuilderPhaseMemory, HybridCacheBuilderPhaseStorage},
+        cache::{HybridCache, HybridCacheEntry, HybridFetch, HybridFetchInner},
+        writer::{HybridCacheStorageWriter, HybridCacheWriter},
+    },
+    memory::{
+        Cache, CacheBuilder, CacheContext, CacheEntry, EvictionConfig, FetchState, FifoConfig, LfuConfig, LruConfig,
+        S3FifoConfig, Weighter,
+    },
+    storage::{
+        AdmissionPicker, AdmitAllPicker, Compression, Dev, DevConfig, DevExt, DeviceStats, DirectFileDevice,
+        DirectFileDeviceOptions, DirectFsDevice, DirectFsDeviceOptions, Engine, EvictionPicker, FifoPicker,
+        InvalidRatioPicker, LargeEngineOptions, RateLimitPicker, RecoverMode, ReinsertionPicker, RejectAllPicker,
+        Runtime, RuntimeOptions, SmallEngineOptions, Storage, Store, StoreBuilder, TokioRuntimeOptions,
+        TombstoneLogConfigBuilder,
+    },
 };

--- a/foyer/src/prelude.rs
+++ b/foyer/src/prelude.rs
@@ -12,18 +12,18 @@
 //  See the License for the specific language governing permissions and
 //  limitations under the License.
 
-pub use common::{
+pub use crate::common::{
     buf::{BufExt, BufMutExt},
     code::{Key, StorageKey, StorageValue, Value},
     event::EventListener,
     range::RangeBoundsExt,
     tracing::TracingOptions,
 };
-pub use memory::{
+pub use crate::memory::{
     Cache, CacheBuilder, CacheContext, CacheEntry, EvictionConfig, FetchState, FifoConfig, LfuConfig, LruConfig,
     S3FifoConfig, Weighter,
 };
-pub use storage::{
+pub use crate::storage::{
     AdmissionPicker, AdmitAllPicker, Compression, Dev, DevConfig, DevExt, DeviceStats, DirectFileDevice,
     DirectFileDeviceOptions, DirectFsDevice, DirectFsDeviceOptions, Engine, EvictionPicker, FifoPicker,
     InvalidRatioPicker, LargeEngineOptions, RateLimitPicker, RecoverMode, ReinsertionPicker, RejectAllPicker, Runtime,
@@ -35,4 +35,3 @@ pub use crate::hybrid::{
     cache::{HybridCache, HybridCacheEntry, HybridFetch, HybridFetchInner},
     writer::{HybridCacheStorageWriter, HybridCacheWriter},
 };
-use crate::{common, memory, storage};


### PR DESCRIPTION
## What's changed and what's your intention?

> Please explain **IN DETAIL** what the changes are in this PR and why they are needed. :D

Changes

- Rename `RuntimeConfig` and `TokioRuntimeConfig` to `RuntimeOptions` and `TokioRuntimeOptions` for consistency.
- Split `TracingConfig` to `TracingConfig` and `TracingOptions` and refine codes.
- Refine tracing configuration for foyer-bench.

## Checklist

- [x] I have written the necessary rustdoc comments
- [x] I have added the necessary unit tests and integration tests
- [x] I have passed `make all` (or `make fast` instead if the old tests are not modified) in my local environment.

## Related issues or PRs (optional)
#327 