### PR TITLE
refactor: refine small object disk cache

### DIFF
--- a/foyer-storage/src/small/flusher.rs
+++ b/foyer-storage/src/small/flusher.rs
@@ -200,9 +200,7 @@ where
             let set_manager = self.set_manager.clone();
             let stats = self.stats.clone();
             async move {
-                let mut set = set_manager.write(sid).await?;
-                set.apply(&deletions, items);
-                set_manager.apply(set).await?;
+                set_manager.update(sid, &deletions, items).await?;
 
                 stats
                     .cache_write_bytes

--- a/foyer-storage/src/small/mod.rs
+++ b/foyer-storage/src/small/mod.rs
@@ -18,4 +18,5 @@ pub mod flusher;
 pub mod generic;
 pub mod serde;
 pub mod set;
+pub mod set_cache;
 pub mod set_manager;

--- a/foyer-storage/src/small/set.rs
+++ b/foyer-storage/src/small/set.rs
@@ -15,8 +15,7 @@
 use std::{
     collections::HashSet,
     fmt::Debug,
-    ops::{Deref, DerefMut, Range},
-    sync::Arc,
+    ops::Range,
     time::{SystemTime, UNIX_EPOCH},
 };
 
@@ -31,54 +30,6 @@ use crate::{
 };
 
 pub type SetId = u64;
-
-#[derive(Debug)]
-pub struct Set {
-    storage: Arc<SetStorage>,
-}
-
-impl Deref for Set {
-    type Target = SetStorage;
-
-    fn deref(&self) -> &Self::Target {
-        &self.storage
-    }
-}
-
-impl Set {
-    pub fn new(storage: Arc<SetStorage>) -> Self {
-        Self { storage }
-    }
-}
-
-#[derive(Debug)]
-pub struct SetMut {
-    storage: SetStorage,
-}
-
-impl Deref for SetMut {
-    type Target = SetStorage;
-
-    fn deref(&self) -> &Self::Target {
-        &self.storage
-    }
-}
-
-impl DerefMut for SetMut {
-    fn deref_mut(&mut self) -> &mut Self::Target {
-        &mut self.storage
-    }
-}
-
-impl SetMut {
-    pub fn new(storage: SetStorage) -> Self {
-        Self { storage }
-    }
-
-    pub fn into_storage(self) -> SetStorage {
-        self.storage
-    }
-}
 
 /// # Format
 ///

--- a/foyer-storage/src/small/set_cache.rs
+++ b/foyer-storage/src/small/set_cache.rs
@@ -1,0 +1,72 @@
+//  Copyright 2024 foyer Project Authors
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//  http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+
+use itertools::Itertools;
+use ordered_hash_map::OrderedHashMap;
+use parking_lot::{MappedRwLockReadGuard, RwLock, RwLockReadGuard};
+
+use super::set::{SetId, SetStorage};
+
+#[derive(Debug)]
+pub struct SetCacheShard {
+    cache: OrderedHashMap<SetId, SetStorage>,
+    capacity: usize,
+}
+
+/// In-memory set cache to reduce disk io.
+///
+/// Simple FIFO cache.
+#[derive(Debug)]
+pub struct SetCache {
+    shards: Vec<RwLock<SetCacheShard>>,
+}
+
+impl SetCache {
+    pub fn new(capacity: usize, shards: usize) -> Self {
+        let shard_capacity = capacity / shards;
+        let shards = (0..shards)
+            .map(|_| {
+                RwLock::new(SetCacheShard {
+                    cache: OrderedHashMap::with_capacity(shard_capacity),
+                    capacity: shard_capacity,
+                })
+            })
+            .collect_vec();
+        Self { shards }
+    }
+
+    pub fn insert(&self, id: SetId, storage: SetStorage) {
+        let mut shard = self.shards[self.shard(&id)].write();
+        if shard.cache.len() == shard.capacity {
+            shard.cache.pop_front();
+        }
+
+        assert!(shard.cache.len() < shard.capacity);
+
+        shard.cache.insert(id, storage);
+    }
+
+    pub fn invalid(&self, id: &SetId) {
+        let mut shard = self.shards[self.shard(id)].write();
+        shard.cache.remove(id);
+    }
+
+    pub fn lookup(&self, id: &SetId) -> Option<MappedRwLockReadGuard<'_, SetStorage>> {
+        RwLockReadGuard::try_map(self.shards[self.shard(id)].read(), |shard| shard.cache.get(id)).ok()
+    }
+
+    fn shard(&self, id: &SetId) -> usize {
+        *id as usize % self.shards.len()
+    }
+}

--- a/foyer-storage/src/store.rs
+++ b/foyer-storage/src/store.rs
@@ -570,6 +570,7 @@ where
                             EngineEnum::open(EngineConfig::Small(GenericSmallStorageConfig {
                                 set_size: self.small.set_size,
                                 set_cache_capacity: self.small.set_cache_capacity,
+                                set_cache_shards: self.small.set_cache_shards,
                                 device,
                                 regions,
                                 flush: self.flush,
@@ -590,6 +591,7 @@ where
                                 left: GenericSmallStorageConfig {
                                     set_size: self.small.set_size,
                                     set_cache_capacity: self.small.set_cache_capacity,
+                                    set_cache_shards: self.small.set_cache_shards,
                                     device: device.clone(),
                                     regions: small_regions,
                                     flush: self.flush,
@@ -818,6 +820,7 @@ where
 {
     set_size: usize,
     set_cache_capacity: usize,
+    set_cache_shards: usize,
     buffer_pool_size: usize,
     flushers: usize,
 
@@ -847,6 +850,7 @@ where
         Self {
             set_size: 16 * 1024,    // 16 KiB
             set_cache_capacity: 64, // 64 sets
+            set_cache_shards: 4,
             flushers: 1,
             buffer_pool_size: 4 * 1024 * 1024, // 4 MiB
             _marker: PhantomData,
@@ -871,6 +875,14 @@ where
     /// Default: 64
     pub fn with_set_cache_capacity(mut self, set_cache_capacity: usize) -> Self {
         self.set_cache_capacity = set_cache_capacity;
+        self
+    }
+
+    /// Set the shards of the set cache.
+    ///
+    /// Default: 4
+    pub fn with_set_cache_shards(mut self, set_cache_shards: usize) -> Self {
+        self.set_cache_shards = set_cache_shards;
         self
     }
 


### PR DESCRIPTION
## What's changed and what's your intention?

> Please explain **IN DETAIL** what the changes are in this PR and why they are needed. :D

FYI: #759 

**Lock Order**:

load (async set cache, not good):

 ```plain
                                                                  |------------ requires async mutex -------------|
 lock(R) bloom filter => unlock(R) bloom filter => lock(R) set => lock(e) set cache => load => unlock(e) set cache => unlock(r) set
 ```

load (sync set cache, good):

 ```plain
 lock(R) bloom filter => unlock(R) bloom filter => lock(R) set => lock(e) set cache => unlock(e) set cache => load => lock(e) set cache => unlock(e) set cache => unlock(r) set
 ```

update:

 ```plain
 lock(W) set => lock(e) set cache => invalid set cache => unlock(e) set cache => update set => lock(w) bloom filter => unlock(w) bloom filter => unlock(w) set
 ```

## Checklist

- [x] I have written the necessary rustdoc comments
- [x] I have added the necessary unit tests and integration tests
- [x] I have passed `make all` (or `make fast` instead if the old tests are not modified) in my local environment.

## Related issues or PRs (optional)
close #759 