### PR TITLE
fix: do not scale in shards when capacity is not enough, just warn

### DIFF
--- a/foyer-memory/src/cache.rs
+++ b/foyer-memory/src/cache.rs
@@ -401,14 +401,13 @@ where
     }
 
     /// Build in-memory cache with the given configuration.
-    pub fn build(mut self) -> Cache<K, V, S> {
+    pub fn build(self) -> Cache<K, V, S> {
         if self.capacity < self.shards {
             tracing::warn!(
-                "The in-memory cache capacity({}) < shards({})",
+                "The in-memory cache capacity({}) < shards({}).",
                 self.capacity,
                 self.shards
             );
-            self.shards = 1;
         }
 
         match self.eviction_config {
@@ -888,12 +887,6 @@ mod tests {
     const RANGE: Range<u64> = 0..1000;
     const OPS: usize = 10000;
     const CONCURRENCY: usize = 8;
-
-    #[test]
-    fn test_not_enough_capacity() {
-        let cache: Cache<u64, u64> = CacheBuilder::new(4).with_shards(64).build();
-        assert_eq!(cache.shards(), 1);
-    }
 
     fn fifo() -> Cache<u64, u64> {
         CacheBuilder::new(CAPACITY)

--- a/foyer-memory/src/generic.rs
+++ b/foyer-memory/src/generic.rs
@@ -497,8 +497,6 @@ where
     S: HashBuilder,
 {
     pub fn new(config: GenericCacheConfig<K, V, E, S>) -> Self {
-        assert!(config.capacity >= config.shards);
-
         let metrics = Arc::new(Metrics::new(&config.name));
 
         let usages = (0..config.shards).map(|_| Arc::new(AtomicUsize::new(0))).collect_vec();


### PR DESCRIPTION
## What's changed and what's your intention?

> Please explain **IN DETAIL** what the changes are in this PR and why they are needed. :D

Sometimes, it is still useful.

## Checklist

- [x] I have written the necessary rustdoc comments
- [x] I have added the necessary unit tests and integration tests
- [x] I have passed `make all` (or `make fast` instead if the old tests are not modified) in my local environment.

## Related issues or PRs (optional)
fix #768 