### PR TITLE
perf: don't iter evicted entries with noop disk cache

### DIFF
--- a/foyer-memory/Cargo.toml
+++ b/foyer-memory/Cargo.toml
@@ -14,6 +14,7 @@ readme = { workspace = true }
 
 [dependencies]
 ahash = { workspace = true }
+arc-swap = "1"
 bitflags = "2"
 cmsketch = "0.2.1"
 equivalent = { workspace = true }

--- a/foyer-storage/src/store.rs
+++ b/foyer-storage/src/store.rs
@@ -647,6 +647,11 @@ where
 
         Ok(store)
     }
+
+    /// Return true the builder is based on a noop device.
+    pub fn is_noop(&self) -> bool {
+        matches! {self.device_options, DeviceOptions::None}
+    }
 }
 
 /// Large object disk cache engine default options.

--- a/foyer/src/hybrid/cache.rs
+++ b/foyer/src/hybrid/cache.rs
@@ -18,7 +18,7 @@ use std::{
     hash::Hash,
     sync::{
         atomic::{AtomicBool, Ordering},
-        Arc, OnceLock,
+        Arc,
     },
     time::Instant,
 };
@@ -72,7 +72,7 @@ where
     V: StorageValue,
     S: HashBuilder + Debug,
 {
-    store: OnceLock<Store<K, V, S>>,
+    store: Store<K, V, S>,
 }
 
 impl<K, V, S> HybridCachePipe<K, V, S>
@@ -81,12 +81,8 @@ where
     V: StorageValue,
     S: HashBuilder + Debug,
 {
-    pub fn new() -> Self {
-        Self { store: OnceLock::new() }
-    }
-
-    pub fn set(&self, store: Store<K, V, S>) {
-        self.store.set(store).unwrap();
+    pub fn new(store: Store<K, V, S>) -> Self {
+        Self { store }
     }
 }
 
@@ -99,8 +95,12 @@ where
     type Key = K;
     type Value = V;
 
+    fn is_enabled(&self) -> bool {
+        true
+    }
+
     fn send(&self, piece: Piece<Self::Key, Self::Value>) {
-        self.store.get().as_ref().unwrap().enqueue(piece, false);
+        self.store.enqueue(piece, false);
     }
 }
 


### PR DESCRIPTION
## What's changed and what's your intention?

> Please explain **IN DETAIL** what the changes are in this PR and why they are needed. :D

This PR bypass the iteration with noop disk cache.

## Checklist

- [x] I have written the necessary rustdoc comments
- [x] I have added the necessary unit tests and integration tests
- [x] I have passed `make all` (or `make fast` instead if the old tests are not modified) in my local environment.

## Related issues or PRs (optional)
#830 