### PR TITLE
ci: more safe ci using zizmor

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,6 +27,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v4
+        with:
+          persist-credentials: false
       - name: Run typos check
         uses: crate-ci/typos@master
       - name: Install yq
@@ -49,6 +51,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v4
+        with:
+          persist-credentials: false
       - name: Cache Cargo home
         uses: actions/cache@v4
         id: cache
@@ -75,6 +79,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v4
+        with:
+          persist-credentials: false
       - name: Run cargo machete
         uses: bnjbvr/cargo-machete@main
   rust-udeps:
@@ -87,6 +93,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v4
+        with:
+          persist-credentials: false
       - name: Install rust toolchain
         uses: dtolnay/rust-toolchain@master
         with:
@@ -123,6 +131,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v4
+        with:
+          persist-credentials: false
       - name: Install rust toolchain
         uses: dtolnay/rust-toolchain@master
         with:
@@ -159,6 +169,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v4
+        with:
+          persist-credentials: false
       - name: Install rust toolchain
         uses: dtolnay/rust-toolchain@master
         with:
@@ -248,6 +260,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v4
+        with:
+          persist-credentials: false
       - name: Install rust toolchain
         uses: dtolnay/rust-toolchain@master
         with:
@@ -290,6 +304,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v4
+        with:
+          persist-credentials: false
       - name: Install rust toolchain
         uses: dtolnay/rust-toolchain@master
         with:
@@ -323,10 +339,12 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v4
+        with:
+          persist-credentials: false
       - name: Install rust toolchain
         uses: dtolnay/rust-toolchain@master
         with:
-          toolchain: ${{ env.RUST_TOOLCHAIN_NIGHTLY }}
+          toolchain: $RUST_TOOLCHAIN_NIGHTLY
       - name: Cache Cargo home
         uses: actions/cache@v4
         id: cache
@@ -343,16 +361,18 @@ jobs:
           RUSTFLAGS: "-Zsanitizer=address --cfg tokio_unstable"
           RUST_LOG: info
           CI: true
+          RUST_TOOLCHAIN_NIGHTLY: nightly-2024-08-30
         run: |-
-          cargo +${{ env.RUST_TOOLCHAIN_NIGHTLY }} test --lib --bins --tests --target x86_64-unknown-linux-gnu -- --nocapture
+          cargo +$RUST_TOOLCHAIN_NIGHTLY test --lib --bins --tests --target x86_64-unknown-linux-gnu -- --nocapture
       - name: Run foyer-bench With Address Sanitizer
         env:
           RUST_BACKTRACE: 1
           RUSTFLAGS: "-Zsanitizer=address --cfg tokio_unstable"
           RUST_LOG: info
           CI: true
+          RUST_TOOLCHAIN_NIGHTLY: nightly-2024-08-30
         run: |-
-          cargo +${{ env.RUST_TOOLCHAIN_NIGHTLY }} build --all --target x86_64-unknown-linux-gnu
+          cargo +$RUST_TOOLCHAIN_NIGHTLY build --all --target x86_64-unknown-linux-gnu
           mkdir -p $GITHUB_WORKSPACE/foyer-data/foyer-bench/asan
           timeout 2m ./target/x86_64-unknown-linux-gnu/debug/foyer-bench --dir $GITHUB_WORKSPACE/foyer-data/foyer-bench/asan --engine large --mem 16MiB --disk 256MiB --region-size 16MiB --get-range 1000 --w-rate 1MiB --r-rate 1MiB --admission-rate-limit 10MiB --entry-size-min 2KiB --entry-size-max 128KiB --time 60
           timeout 2m ./target/x86_64-unknown-linux-gnu/debug/foyer-bench --dir $GITHUB_WORKSPACE/foyer-data/foyer-bench/asan --engine small --mem 4MiB --disk 256MiB --region-size 16MiB --get-range 1000 --w-rate 1MiB --r-rate 1MiB --admission-rate-limit 1MiB --entry-size-min 1KiB --entry-size-max 24KiB --time 60
@@ -373,6 +393,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v4
+        with:
+          persist-credentials: false
       - name: Install rust toolchain
         uses: dtolnay/rust-toolchain@master
         with:

--- a/.github/workflows/license_check.yml
+++ b/.github/workflows/license_check.yml
@@ -14,6 +14,8 @@ jobs:
     runs-on: ubuntu-latest
     name: license-header-check
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
+      with:
+        persist-credentials: false
     - name: Check License Header
       uses: apache/skywalking-eyes/header@v0.6.0


### PR DESCRIPTION
## What's changed and what's your intention?

> Please explain **IN DETAIL** what the changes are in this PR and why they are needed. :D

As more and more attackers using GitHub Actions to steal the token or attack other users such as Mining Scripts

this patch fix more of them

zizmor: https://woodruffw.github.io/zizmor/

more can check issue [one-api](https://github.com/songquanpeng/one-api/issues/2000) or https://www.praetorian.com/blog/compromising-bytedances-rspack-github-actions-vulnerabilities/
we can use static check to avoid them as we can.

e.g.:

https://github.com/astral-sh/ruff/pull/14844

same request for opendal https://github.com/apache/opendal/issues/5502

## Checklist

- [ ] I have written the necessary rustdoc comments
- [ ] I have added the necessary unit tests and integration tests
- [ ] I have passed `make all` (or `make fast` instead if the old tests are not modified) in my local environment.

## Related issues or PRs (optional)
