### PR TITLE
refactor: remove unnecessary piece holder in batch

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -81,6 +81,10 @@ jobs:
         uses: actions/checkout@v4
         with:
           persist-credentials: false
+      - name: Install rust toolchain
+        uses: dtolnay/rust-toolchain@master
+        with:
+          toolchain: stable
       - name: Run cargo machete
         uses: bnjbvr/cargo-machete@main
   rust-udeps:

--- a/foyer-common/src/runtime.rs
+++ b/foyer-common/src/runtime.rs
@@ -205,15 +205,15 @@ impl SingletonHandle {
     /// }
     /// ```
     ///
-    /// [`JoinError`]: struct@crate::task::JoinError
-    /// [`JoinHandle`]: struct@crate::task::JoinHandle
+    /// [`JoinError`]: struct@tokio::task::JoinError
+    /// [`JoinHandle`]: struct@tokio::task::JoinHandle
     /// [`Runtime::block_on`]: fn@crate::runtime::Runtime::block_on
-    /// [`Runtime::shutdown_background`]: fn@crate::runtime::Runtime::shutdown_background
-    /// [`Runtime::shutdown_timeout`]: fn@crate::runtime::Runtime::shutdown_timeout
-    /// [`spawn_blocking`]: crate::task::spawn_blocking
-    /// [`tokio::fs`]: crate::fs
-    /// [`tokio::net`]: crate::net
-    /// [`tokio::time`]: crate::time
+    /// [`Runtime::shutdown_background`]: fn@tokio::runtime::Runtime::shutdown_background
+    /// [`Runtime::shutdown_timeout`]: fn@tokio::runtime::Runtime::shutdown_timeout
+    /// [`spawn_blocking`]: tokio::task::spawn_blocking
+    /// [`tokio::fs`]: tokio::fs
+    /// [`tokio::net`]: tokio::net
+    /// [`tokio::time`]: tokio::time
     #[cfg(not(madsim))]
     pub fn block_on<F: Future>(&self, future: F) -> F::Output {
         self.0.block_on(future)

--- a/foyer-storage/src/serde.rs
+++ b/foyer-storage/src/serde.rs
@@ -44,6 +44,7 @@ pub struct KvInfo {
     pub value_len: usize,
 }
 
+/// A writer wrapper that count how many bytes has been written.
 #[derive(Debug)]
 pub struct TrackedWriter<W> {
     inner: W,

--- a/foyer-storage/src/small/batch.rs
+++ b/foyer-storage/src/small/batch.rs
@@ -40,46 +40,21 @@ use crate::{
 type Sequence = usize;
 
 #[derive(Debug)]
-struct ItemMut<K, V>
-where
-    K: StorageKey,
-    V: StorageValue,
-{
+struct ItemMut {
     range: Range<usize>,
-    piece: Piece<K, V>,
+    hash: u64,
     sequence: Sequence,
 }
 
-#[derive(Debug)]
-struct SetBatchMut<K, V>
-where
-    K: StorageKey,
-    V: StorageValue,
-{
-    items: Vec<ItemMut<K, V>>,
+#[derive(Debug, Default)]
+struct SetBatchMut {
+    items: Vec<ItemMut>,
     deletes: HashMap<u64, Sequence>,
 }
 
-impl<K, V> Default for SetBatchMut<K, V>
-where
-    K: StorageKey,
-    V: StorageValue,
-{
-    fn default() -> Self {
-        Self {
-            items: vec![],
-            deletes: HashMap::new(),
-        }
-    }
-}
-
 #[derive(Debug)]
-pub struct BatchMut<K, V>
-where
-    K: StorageKey,
-    V: StorageValue,
-{
-    sets: HashMap<SetId, SetBatchMut<K, V>>,
+pub struct BatchMut {
+    sets: HashMap<SetId, SetBatchMut>,
     buffer: IoBuffer,
     len: usize,
     sequence: Sequence,
@@ -95,11 +70,7 @@ where
     metrics: Arc<Metrics>,
 }
 
-impl<K, V> BatchMut<K, V>
-where
-    K: StorageKey,
-    V: StorageValue,
-{
+impl BatchMut {
     pub fn new(sets: usize, buffer_size: usize, metrics: Arc<Metrics>) -> Self {
         let buffer_size = bits::align_up(ALIGN, buffer_size);
 
@@ -116,7 +87,11 @@ where
         }
     }
 
-    pub fn insert(&mut self, piece: Piece<K, V>, estimated_size: usize) -> bool {
+    pub fn insert<K, V>(&mut self, piece: Piece<K, V>, estimated_size: usize) -> bool
+    where
+        K: StorageKey,
+        V: StorageValue,
+    {
         // For the small object disk cache does NOT compress entries, `estimated_size` is actually `exact_size`.
         tracing::trace!("[sodc batch]: insert entry");
 
@@ -156,7 +131,7 @@ where
 
         set.items.push(ItemMut {
             range: self.len..self.len + len,
-            piece,
+            hash: piece.hash(),
             sequence: self.sequence,
         });
         self.len += len;
@@ -193,7 +168,7 @@ where
         self.init.is_none()
     }
 
-    pub fn rotate(&mut self) -> Option<Batch<K, V>> {
+    pub fn rotate(&mut self) -> Option<Batch> {
         if self.is_empty() {
             return None;
         }
@@ -212,10 +187,10 @@ where
                 let items = batch
                     .items
                     .into_iter()
-                    .filter(|item| item.sequence >= batch.deletes.get(&item.piece.hash()).copied().unwrap_or_default())
+                    .filter(|item| item.sequence >= batch.deletes.get(&item.hash).copied().unwrap_or_default())
                     .map(|item| Item {
                         buffer: buffer.slice(item.range),
-                        piece: item.piece,
+                        hash: item.hash,
                     })
                     .collect_vec();
                 let deletes = batch.deletes.keys().copied().collect();
@@ -236,39 +211,23 @@ where
     }
 }
 
-pub struct Item<K, V>
-where
-    K: StorageKey,
-    V: StorageValue,
-{
+pub struct Item {
     pub buffer: IoBytes,
-    pub piece: Piece<K, V>,
+    pub hash: u64,
 }
 
-impl<K, V> Debug for Item<K, V>
-where
-    K: StorageKey,
-    V: StorageValue,
-{
+impl Debug for Item {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        f.debug_struct("Item").field("hash", &self.piece.hash()).finish()
+        f.debug_struct("Item").field("hash", &self.hash).finish()
     }
 }
 
-pub struct SetBatch<K, V>
-where
-    K: StorageKey,
-    V: StorageValue,
-{
+pub struct SetBatch {
     pub deletions: HashSet<u64>,
-    pub items: Vec<Item<K, V>>,
+    pub items: Vec<Item>,
 }
 
-impl<K, V> Debug for SetBatch<K, V>
-where
-    K: StorageKey,
-    V: StorageValue,
-{
+impl Debug for SetBatch {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         f.debug_struct("SetBatch")
             .field("deletes", &self.deletions)
@@ -277,40 +236,9 @@ where
     }
 }
 
-pub struct Batch<K, V>
-where
-    K: StorageKey,
-    V: StorageValue,
-{
-    pub sets: HashMap<SetId, SetBatch<K, V>>,
+#[derive(Debug, Default)]
+pub struct Batch {
+    pub sets: HashMap<SetId, SetBatch>,
     pub waiters: Vec<oneshot::Sender<()>>,
     pub init: Option<Instant>,
-}
-
-impl<K, V> Default for Batch<K, V>
-where
-    K: StorageKey,
-    V: StorageValue,
-{
-    fn default() -> Self {
-        Self {
-            sets: HashMap::new(),
-            waiters: vec![],
-            init: None,
-        }
-    }
-}
-
-impl<K, V> Debug for Batch<K, V>
-where
-    K: StorageKey,
-    V: StorageValue,
-{
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        f.debug_struct("Batch")
-            .field("sets", &self.sets)
-            .field("waiters", &self.waiters)
-            .field("init", &self.init)
-            .finish()
-    }
 }

--- a/foyer-storage/src/small/set.rs
+++ b/foyer-storage/src/small/set.rs
@@ -142,11 +142,7 @@ impl SetStorage {
         self.buffer.freeze()
     }
 
-    pub fn apply<K, V>(&mut self, deletions: &HashSet<u64>, items: Vec<Item<K, V>>)
-    where
-        K: StorageKey,
-        V: StorageValue,
-    {
+    pub fn apply(&mut self, deletions: &HashSet<u64>, items: Vec<Item>) {
         self.deletes(deletions);
         self.append(items);
     }
@@ -184,11 +180,7 @@ impl SetStorage {
         self.len = wcursor;
     }
 
-    fn append<K, V>(&mut self, items: Vec<Item<K, V>>)
-    where
-        K: StorageKey,
-        V: StorageValue,
-    {
+    fn append(&mut self, items: Vec<Item>) {
         let (skip, size, _) = items
             .iter()
             .rev()
@@ -205,7 +197,7 @@ impl SetStorage {
         let mut cursor = Self::SET_HEADER_SIZE + self.len;
         for item in items.iter().skip(skip) {
             self.buffer[cursor..cursor + item.buffer.len()].copy_from_slice(&item.buffer);
-            self.bloom_filter.insert(item.piece.hash());
+            self.bloom_filter.insert(item.hash);
             cursor += item.buffer.len();
         }
         self.len = cursor - Self::SET_HEADER_SIZE;
@@ -421,7 +413,7 @@ mod tests {
             &HashSet::from_iter([2, 4]),
             vec![Item {
                 buffer: b1.clone(),
-                piece: e1.piece(),
+                hash: e1.hash(),
             }],
         );
         assert_eq!(storage.len(), b1.len());
@@ -433,7 +425,7 @@ mod tests {
             &HashSet::from_iter([e1.hash(), 3, 5]),
             vec![Item {
                 buffer: b2.clone(),
-                piece: e2.piece(),
+                hash: e2.hash(),
             }],
         );
         assert_eq!(storage.len(), b2.len());
@@ -446,7 +438,7 @@ mod tests {
             &HashSet::from_iter([e1.hash()]),
             vec![Item {
                 buffer: b3.clone(),
-                piece: e3.piece(),
+                hash: e3.hash(),
             }],
         );
         assert_eq!(storage.len(), b2.len() + b3.len());
@@ -460,7 +452,7 @@ mod tests {
             &HashSet::from_iter([e1.hash()]),
             vec![Item {
                 buffer: b4.clone(),
-                piece: e4.piece(),
+                hash: e4.hash(),
             }],
         );
         assert_eq!(storage.len(), b4.len());
@@ -490,7 +482,7 @@ mod tests {
             &HashSet::new(),
             vec![Item {
                 buffer: b5.clone(),
-                piece: e5.piece(),
+                hash: e5.hash(),
             }],
         );
         assert_eq!(storage.len(), b4.len());

--- a/foyer-storage/src/small/set_manager.rs
+++ b/foyer-storage/src/small/set_manager.rs
@@ -170,11 +170,7 @@ impl SetManager {
         res
     }
 
-    pub async fn update<K, V>(&self, sid: SetId, deletions: &HashSet<u64>, items: Vec<Item<K, V>>) -> Result<()>
-    where
-        K: StorageKey,
-        V: StorageValue,
-    {
+    pub async fn update(&self, sid: SetId, deletions: &HashSet<u64>, items: Vec<Item>) -> Result<()> {
         // Acquire set lock.
         let set = self.inner.sets[sid as usize].write().await;
 


### PR DESCRIPTION
## What's changed and what's your intention?

> Please explain **IN DETAIL** what the changes are in this PR and why they are needed. :D

- Remove unnecessary `Piece` holders in `Batch`. (unnecessary since #785 )
- Fix warnings with the latest stable Rust toolchain.

## Checklist

- [x] I have written the necessary rustdoc comments
- [x] I have added the necessary unit tests and integration tests
- [x] I have passed `make all` (or `make fast` instead if the old tests are not modified) in my local environment.

## Related issues or PRs (optional)
