### PR TITLE
refactor: use key hash for pickers to minimise reinsertion overhead

### DIFF
--- a/foyer-storage/src/picker/mod.rs
+++ b/foyer-storage/src/picker/mod.rs
@@ -18,20 +18,14 @@ use crate::{device::RegionId, region::RegionStats, statistics::Statistics};
 
 /// The admission picker for the disk cache.
 pub trait AdmissionPicker: Send + Sync + 'static + Debug {
-    /// The key type for the admission picker.
-    type Key;
-
-    /// Decide whether to pick a key.
-    fn pick(&self, stats: &Arc<Statistics>, key: &Self::Key) -> bool;
+    /// Decide whether to pick an entry by hash.
+    fn pick(&self, stats: &Arc<Statistics>, hash: u64) -> bool;
 }
 
 /// The reinsertion picker for the disk cache.
 pub trait ReinsertionPicker: Send + Sync + 'static + Debug {
-    /// The key type for the reinsertion picker.
-    type Key;
-
-    /// Decide whether to pick a key.
-    fn pick(&self, stats: &Arc<Statistics>, key: &Self::Key) -> bool;
+    /// Decide whether to pick an entry by hash.
+    fn pick(&self, stats: &Arc<Statistics>, hash: u64) -> bool;
 }
 
 /// The eviction picker for the disk cache.

--- a/foyer-storage/src/test_utils.rs
+++ b/foyer-storage/src/test_utils.rs
@@ -14,9 +14,8 @@
 
 //! Test utils for the `foyer-storage` crate.
 
-use std::{borrow::Borrow, collections::HashSet, fmt::Debug, hash::Hash, sync::Arc};
+use std::{collections::HashSet, fmt::Debug, sync::Arc};
 
-use foyer_common::code::StorageKey;
 use parking_lot::Mutex;
 
 use crate::{
@@ -24,87 +23,58 @@ use crate::{
     statistics::Statistics,
 };
 
-/// A picker that only admits key from the given list.
-pub struct BiasedPicker<K> {
-    admits: HashSet<K>,
+/// A picker that only admits hash from the given list.
+#[derive(Debug)]
+pub struct BiasedPicker {
+    admits: HashSet<u64>,
 }
 
-impl<K> Debug for BiasedPicker<K>
-where
-    K: Debug,
-{
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        f.debug_struct("BiasedPicker").field("admits", &self.admits).finish()
-    }
-}
-
-impl<K> BiasedPicker<K> {
+impl BiasedPicker {
     /// Create a biased picker with the given admit list.
-    pub fn new(admits: impl IntoIterator<Item = K>) -> Self
-    where
-        K: Hash + Eq,
-    {
+    pub fn new(admits: impl IntoIterator<Item = u64>) -> Self {
         Self {
             admits: admits.into_iter().collect(),
         }
     }
 }
 
-impl<K> AdmissionPicker for BiasedPicker<K>
-where
-    K: Send + Sync + 'static + Hash + Eq + Debug,
-{
-    type Key = K;
-
-    fn pick(&self, _: &Arc<Statistics>, key: &Self::Key) -> bool {
-        self.admits.contains(key)
+impl AdmissionPicker for BiasedPicker {
+    fn pick(&self, _: &Arc<Statistics>, hash: u64) -> bool {
+        self.admits.contains(&hash)
     }
 }
 
-impl<K> ReinsertionPicker for BiasedPicker<K>
-where
-    K: Send + Sync + 'static + Hash + Eq + Debug,
-{
-    type Key = K;
-
-    fn pick(&self, _: &Arc<Statistics>, key: &Self::Key) -> bool {
-        self.admits.contains(key.borrow())
+impl ReinsertionPicker for BiasedPicker {
+    fn pick(&self, _: &Arc<Statistics>, hash: u64) -> bool {
+        self.admits.contains(&hash)
     }
 }
 
 /// The record entry for admission and eviction.
 #[derive(Debug, Clone)]
-pub enum Record<K> {
-    /// Admission record entry.
-    Admit(K),
-    /// Eviction record entry.
-    Evict(K),
+pub enum Record {
+    /// Admission record entry hash.
+    Admit(u64),
+    /// Eviction record entry hash.
+    Evict(u64),
 }
 
 /// A recorder that records the cache entry admission and eviction of a disk cache.
 ///
 /// [`Recorder`] should be used as both the admission picker and the reinsertion picker to record.
-pub struct Recorder<K> {
-    records: Mutex<Vec<Record<K>>>,
+#[derive(Debug, Default)]
+pub struct Recorder {
+    records: Mutex<Vec<Record>>,
 }
 
-impl<K> Debug for Recorder<K> {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        f.debug_struct("JudgeRecorder").finish()
-    }
-}
-
-impl<K> Recorder<K>
-where
-    K: StorageKey + Clone,
-{
+impl Recorder {
     /// Dump the record entries of the recorder.
-    pub fn dump(&self) -> Vec<Record<K>> {
+    pub fn dump(&self) -> Vec<Record> {
         self.records.lock().clone()
     }
 
-    /// Get the hash set of the remaining key at the moment.
-    pub fn remains(&self) -> HashSet<K> {
+    /// Get the hash set of the remaining hash at the moment.
+    pub fn remains(&self) -> HashSet<u64> {
         let records = self.dump();
         let mut res = HashSet::default();
         for record in records {
@@ -121,37 +91,16 @@ where
     }
 }
 
-impl<K> Default for Recorder<K>
-where
-    K: StorageKey,
-{
-    fn default() -> Self {
-        Self {
-            records: Mutex::new(Vec::default()),
-        }
-    }
-}
-
-impl<K> AdmissionPicker for Recorder<K>
-where
-    K: StorageKey + Clone,
-{
-    type Key = K;
-
-    fn pick(&self, _: &Arc<Statistics>, key: &Self::Key) -> bool {
-        self.records.lock().push(Record::Admit(key.clone()));
+impl AdmissionPicker for Recorder {
+    fn pick(&self, _: &Arc<Statistics>, hash: u64) -> bool {
+        self.records.lock().push(Record::Admit(hash));
         true
     }
 }
 
-impl<K> ReinsertionPicker for Recorder<K>
-where
-    K: StorageKey + Clone,
-{
-    type Key = K;
-
-    fn pick(&self, _: &Arc<Statistics>, key: &Self::Key) -> bool {
-        self.records.lock().push(Record::Evict(key.clone()));
+impl ReinsertionPicker for Recorder {
+    fn pick(&self, _: &Arc<Statistics>, hash: u64) -> bool {
+        self.records.lock().push(Record::Evict(hash));
         false
     }
 }

--- a/foyer-storage/tests/storage_fuzzy_test.rs
+++ b/foyer-storage/tests/storage_fuzzy_test.rs
@@ -18,8 +18,7 @@
 
 use std::{path::Path, sync::Arc};
 
-use ahash::RandomState;
-use foyer_common::metrics::Metrics;
+use foyer_common::{hasher::ModRandomState, metrics::Metrics};
 use foyer_memory::{Cache, CacheBuilder, FifoConfig};
 use foyer_storage::{
     test_utils::Recorder, Compression, DirectFsDeviceOptions, Engine, LargeEngineOptions, StoreBuilder,
@@ -32,9 +31,9 @@ const INSERTS: usize = 100;
 const LOOPS: usize = 10;
 
 async fn test_store(
-    memory: Cache<u64, Vec<u8>>,
-    builder: impl Fn(&Cache<u64, Vec<u8>>) -> StoreBuilder<u64, Vec<u8>, RandomState>,
-    recorder: Arc<Recorder<u64>>,
+    memory: Cache<u64, Vec<u8>, ModRandomState>,
+    builder: impl Fn(&Cache<u64, Vec<u8>, ModRandomState>) -> StoreBuilder<u64, Vec<u8>, ModRandomState>,
+    recorder: Arc<Recorder>,
 ) {
     let store = builder(&memory).build().await.unwrap();
 
@@ -101,10 +100,10 @@ async fn test_store(
 }
 
 fn basic(
-    memory: &Cache<u64, Vec<u8>>,
+    memory: &Cache<u64, Vec<u8>, ModRandomState>,
     path: impl AsRef<Path>,
-    recorder: &Arc<Recorder<u64>>,
-) -> StoreBuilder<u64, Vec<u8>> {
+    recorder: &Arc<Recorder>,
+) -> StoreBuilder<u64, Vec<u8>, ModRandomState> {
     // TODO(MrCroxx): Test mixed engine here.
     StoreBuilder::new("test", memory.clone(), Arc::new(Metrics::noop()), Engine::Large)
         .with_device_options(
@@ -126,9 +125,12 @@ fn basic(
 async fn test_direct_fs_store() {
     let tempdir = tempfile::tempdir().unwrap();
     let recorder = Arc::new(Recorder::default());
-    let memory = CacheBuilder::new(1).with_eviction_config(FifoConfig::default()).build();
+    let memory = CacheBuilder::new(1)
+        .with_eviction_config(FifoConfig::default())
+        .with_hash_builder(ModRandomState::default())
+        .build();
     let r = recorder.clone();
-    let builder = |memory: &Cache<u64, Vec<u8>>| basic(memory, tempdir.path(), &r);
+    let builder = |memory: &Cache<u64, Vec<u8>, ModRandomState>| basic(memory, tempdir.path(), &r);
     test_store(memory, builder, recorder).await;
 }
 
@@ -136,9 +138,14 @@ async fn test_direct_fs_store() {
 async fn test_direct_fs_store_zstd() {
     let tempdir = tempfile::tempdir().unwrap();
     let recorder = Arc::new(Recorder::default());
-    let memory = CacheBuilder::new(1).with_eviction_config(FifoConfig::default()).build();
+    let memory = CacheBuilder::new(1)
+        .with_eviction_config(FifoConfig::default())
+        .with_hash_builder(ModRandomState::default())
+        .build();
     let r = recorder.clone();
-    let builder = |memory: &Cache<u64, Vec<u8>>| basic(memory, tempdir.path(), &r).with_compression(Compression::Zstd);
+    let builder = |memory: &Cache<u64, Vec<u8>, ModRandomState>| {
+        basic(memory, tempdir.path(), &r).with_compression(Compression::Zstd)
+    };
     test_store(memory, builder, recorder).await;
 }
 
@@ -146,8 +153,13 @@ async fn test_direct_fs_store_zstd() {
 async fn test_direct_fs_store_lz4() {
     let tempdir = tempfile::tempdir().unwrap();
     let recorder = Arc::new(Recorder::default());
-    let memory = CacheBuilder::new(1).with_eviction_config(FifoConfig::default()).build();
+    let memory = CacheBuilder::new(1)
+        .with_eviction_config(FifoConfig::default())
+        .with_hash_builder(ModRandomState::default())
+        .build();
     let r = recorder.clone();
-    let builder = |memory: &Cache<u64, Vec<u8>>| basic(memory, tempdir.path(), &r).with_compression(Compression::Lz4);
+    let builder = |memory: &Cache<u64, Vec<u8>, ModRandomState>| {
+        basic(memory, tempdir.path(), &r).with_compression(Compression::Lz4)
+    };
     test_store(memory, builder, recorder).await;
 }

--- a/foyer/src/hybrid/builder.rs
+++ b/foyer/src/hybrid/builder.rs
@@ -264,7 +264,7 @@ where
     /// The admission picker is used to pick the entries that can be inserted into the disk cache store.
     ///
     /// Default: [`crate::AdmitAllPicker`].
-    pub fn with_admission_picker(self, admission_picker: Arc<dyn AdmissionPicker<Key = K>>) -> Self {
+    pub fn with_admission_picker(self, admission_picker: Arc<dyn AdmissionPicker>) -> Self {
         let builder = self.builder.with_admission_picker(admission_picker);
         Self {
             name: self.name,

--- a/foyer/src/hybrid/cache.rs
+++ b/foyer/src/hybrid/cache.rs
@@ -521,6 +521,7 @@ mod tests {
 
     use std::{path::Path, sync::Arc};
 
+    use foyer_common::hasher::ModRandomState;
     use storage::test_utils::BiasedPicker;
 
     use crate::*;
@@ -528,10 +529,11 @@ mod tests {
     const KB: usize = 1024;
     const MB: usize = 1024 * 1024;
 
-    async fn open(dir: impl AsRef<Path>) -> HybridCache<u64, Vec<u8>> {
+    async fn open(dir: impl AsRef<Path>) -> HybridCache<u64, Vec<u8>, ModRandomState> {
         HybridCacheBuilder::new()
             .with_name("test")
             .memory(4 * MB)
+            .with_hash_builder(ModRandomState::default())
             // TODO(MrCroxx): Test with `Engine::Mixed`.
             .storage(Engine::Large)
             .with_device_options(
@@ -547,10 +549,11 @@ mod tests {
     async fn open_with_biased_admission_picker(
         dir: impl AsRef<Path>,
         admits: impl IntoIterator<Item = u64>,
-    ) -> HybridCache<u64, Vec<u8>> {
+    ) -> HybridCache<u64, Vec<u8>, ModRandomState> {
         HybridCacheBuilder::new()
             .with_name("test")
             .memory(4 * MB)
+            .with_hash_builder(ModRandomState::default())
             // TODO(MrCroxx): Test with `Engine::Mixed`.
             .storage(Engine::Large)
             .with_device_options(

--- a/foyer/src/hybrid/writer.rs
+++ b/foyer/src/hybrid/writer.rs
@@ -69,6 +69,7 @@ where
 {
     hybrid: HybridCache<K, V, S>,
     key: K,
+    hash: u64,
 
     picked: Option<bool>,
     pick_duration: Duration,
@@ -81,9 +82,11 @@ where
     S: HashBuilder + Debug,
 {
     pub(crate) fn new(hybrid: HybridCache<K, V, S>, key: K) -> Self {
+        let hash = hybrid.memory().hash(&key);
         Self {
             hybrid,
             key,
+            hash,
             picked: None,
             pick_duration: Duration::default(),
         }
@@ -99,7 +102,7 @@ where
         }
         let now = Instant::now();
 
-        let picked = self.hybrid.storage().pick(&self.key);
+        let picked = self.hybrid.storage().pick(self.hash);
         self.picked = Some(picked);
 
         self.pick_duration = now.elapsed();


### PR DESCRIPTION
## What's changed and what's your intention?

> Please explain **IN DETAIL** what the changes are in this PR and why they are needed. :D

In most cases, the picker by key is not necessary. However, it requires additional deserialization of the entry key. The overhead is okay for now, but unacceptable with blob format optimization.

This PR replaces the picker trait by key with by hash.

## Checklist

- [x] I have written the necessary rustdoc comments
- [x] I have added the necessary unit tests and integration tests
- [x] I have passed `make all` (or `make fast` instead if the old tests are not modified) in my local environment.

## Related issues or PRs (optional)
#863 #866 