### PR TITLE
perf: split large io by flush_io_size in the new model

### DIFF
--- a/foyer-storage/src/large/generic.rs
+++ b/foyer-storage/src/large/generic.rs
@@ -76,6 +76,7 @@ where
     pub reclaimers: usize,
     pub buffer_pool_size: usize,
     pub submit_queue_size_threshold: usize,
+    pub flush_io_size: usize,
     pub clean_region_threshold: usize,
     pub eviction_pickers: Vec<Box<dyn EvictionPicker>>,
     pub reinsertion_picker: Arc<dyn ReinsertionPicker>,
@@ -102,6 +103,7 @@ where
             .field("reclaimers", &self.reclaimers)
             .field("buffer_pool_size", &self.buffer_pool_size)
             .field("submit_queue_size_threshold", &self.submit_queue_size_threshold)
+            .field("flush_io_size", &self.flush_io_size)
             .field("clean_region_threshold", &self.clean_region_threshold)
             .field("eviction_pickers", &self.eviction_pickers)
             .field("reinsertion_pickers", &self.reinsertion_picker)
@@ -597,6 +599,7 @@ mod tests {
             tombstone_log_config: None,
             buffer_pool_size: 16 * 1024 * 1024,
             submit_queue_size_threshold: 16 * 1024 * 1024 * 2,
+            flush_io_size: 128 * 1024,
             statistics: Arc::<Statistics>::default(),
             runtime: Runtime::new(None, None, Handle::current()),
             marker: PhantomData,
@@ -626,6 +629,7 @@ mod tests {
             tombstone_log_config: Some(TombstoneLogConfigBuilder::new(path).with_flush(true).build()),
             buffer_pool_size: 16 * 1024 * 1024,
             submit_queue_size_threshold: 16 * 1024 * 1024 * 2,
+            flush_io_size: 128 * 1024,
             statistics: Arc::<Statistics>::default(),
             runtime: Runtime::new(None, None, Handle::current()),
             marker: PhantomData,

--- a/foyer-storage/src/store.rs
+++ b/foyer-storage/src/store.rs
@@ -826,6 +826,28 @@ where
         self.tombstone_log_config = Some(tombstone_log_config);
         self
     }
+
+    /// Limit the maximum flush io size.
+    ///
+    /// One larger disk write while flusing will be split into multiple disk writes based on this value.
+    ///
+    /// The value will be align to 4K if it is not.
+    ///
+    /// Default: 128 * 1024
+    pub fn with_flush_io_size(mut self, flush_io_size: usize) -> Self {
+        self.flush_io_size = flush_io_size;
+        self
+    }
+
+    /// Limit the flush io depth.
+    ///
+    /// Limit the disk writes submitted to the disk based on this value.
+    ///
+    /// Default: 256.
+    pub fn with_flush_io_depth(mut self, flush_io_depth: usize) -> Self {
+        self.flush_io_depth = flush_io_depth;
+        self
+    }
 }
 
 /// Small object disk cache engine default options.

--- a/foyer-storage/src/store.rs
+++ b/foyer-storage/src/store.rs
@@ -563,6 +563,7 @@ where
                                 tombstone_log_config: self.large.tombstone_log_config,
                                 buffer_pool_size: self.large.buffer_pool_size,
                                 submit_queue_size_threshold: self.large.submit_queue_size_threshold.unwrap_or(self.large.buffer_pool_size * 2),
+                                flush_io_size: self.large.flush_io_size,
                                 statistics: statistics.clone(),
                                 runtime,
                                 marker: PhantomData,
@@ -621,6 +622,7 @@ where
                                     tombstone_log_config: self.large.tombstone_log_config,
                                     buffer_pool_size: self.large.buffer_pool_size,
                                     submit_queue_size_threshold: self.large.submit_queue_size_threshold.unwrap_or(self.large.buffer_pool_size * 2),
+                                    flush_io_size: self.large.flush_io_size,
                                     statistics: statistics.clone(),
                                     runtime,
                                     marker: PhantomData,
@@ -670,6 +672,7 @@ where
     reclaimers: usize,
     buffer_pool_size: usize,
     submit_queue_size_threshold: Option<usize>,
+    flush_io_size: usize,
     clean_region_threshold: Option<usize>,
     eviction_pickers: Vec<Box<dyn EvictionPicker>>,
     reinsertion_picker: Arc<dyn ReinsertionPicker>,
@@ -704,6 +707,7 @@ where
             reclaimers: 1,
             buffer_pool_size: 16 * 1024 * 1024, // 16 MiB
             submit_queue_size_threshold: None,
+            flush_io_size: 128 * 1024, // 128 KiB
             clean_region_threshold: None,
             eviction_pickers: vec![Box::new(InvalidRatioPicker::new(0.8)), Box::<FifoPicker>::default()],
             reinsertion_picker: Arc::<RejectAllPicker>::default(),

--- a/foyer-storage/src/store.rs
+++ b/foyer-storage/src/store.rs
@@ -565,6 +565,7 @@ where
                                 submit_queue_size_threshold: self.large.submit_queue_size_threshold.unwrap_or(self.large.buffer_pool_size * 2),
                                 flush_io_size: self.large.flush_io_size,
                                 flush_io_depth: self.large.flush_io_depth,
+                                flush_io_throughput: self.large.flush_io_throughput,
                                 statistics: statistics.clone(),
                                 runtime,
                                 marker: PhantomData,
@@ -625,6 +626,7 @@ where
                                     submit_queue_size_threshold: self.large.submit_queue_size_threshold.unwrap_or(self.large.buffer_pool_size * 2),
                                     flush_io_size: self.large.flush_io_size,
                                     flush_io_depth: self.large.flush_io_depth,
+                                    flush_io_throughput: self.large.flush_io_throughput,
                                     statistics: statistics.clone(),
                                     runtime,
                                     marker: PhantomData,
@@ -676,6 +678,7 @@ where
     submit_queue_size_threshold: Option<usize>,
     flush_io_size: usize,
     flush_io_depth: usize,
+    flush_io_throughput: Option<usize>,
     clean_region_threshold: Option<usize>,
     eviction_pickers: Vec<Box<dyn EvictionPicker>>,
     reinsertion_picker: Arc<dyn ReinsertionPicker>,
@@ -712,6 +715,7 @@ where
             submit_queue_size_threshold: None,
             flush_io_size: 128 * 1024, // 128 KiB
             flush_io_depth: 256,
+            flush_io_throughput: None,
             clean_region_threshold: None,
             eviction_pickers: vec![Box::new(InvalidRatioPicker::new(0.8)), Box::<FifoPicker>::default()],
             reinsertion_picker: Arc::<RejectAllPicker>::default(),
@@ -829,7 +833,7 @@ where
 
     /// Limit the maximum flush io size.
     ///
-    /// One larger disk write while flusing will be split into multiple disk writes based on this value.
+    /// One larger disk write while flushing will be split into multiple disk writes based on this value.
     ///
     /// The value will be align to 4K if it is not.
     ///
@@ -846,6 +850,16 @@ where
     /// Default: 256.
     pub fn with_flush_io_depth(mut self, flush_io_depth: usize) -> Self {
         self.flush_io_depth = flush_io_depth;
+        self
+    }
+
+    /// Limit the flush io throughput.
+    ///
+    /// Limit the disk write throughput submitted to the disk based on this value.
+    ///
+    /// Default: Unlimited.
+    pub fn with_flush_io_throughput(mut self, flush_io_throughput: usize) -> Self {
+        self.flush_io_throughput = Some(flush_io_throughput);
         self
     }
 }

--- a/foyer-storage/src/store.rs
+++ b/foyer-storage/src/store.rs
@@ -564,6 +564,7 @@ where
                                 buffer_pool_size: self.large.buffer_pool_size,
                                 submit_queue_size_threshold: self.large.submit_queue_size_threshold.unwrap_or(self.large.buffer_pool_size * 2),
                                 flush_io_size: self.large.flush_io_size,
+                                flush_io_depth: self.large.flush_io_depth,
                                 statistics: statistics.clone(),
                                 runtime,
                                 marker: PhantomData,
@@ -623,6 +624,7 @@ where
                                     buffer_pool_size: self.large.buffer_pool_size,
                                     submit_queue_size_threshold: self.large.submit_queue_size_threshold.unwrap_or(self.large.buffer_pool_size * 2),
                                     flush_io_size: self.large.flush_io_size,
+                                    flush_io_depth: self.large.flush_io_depth,
                                     statistics: statistics.clone(),
                                     runtime,
                                     marker: PhantomData,
@@ -673,6 +675,7 @@ where
     buffer_pool_size: usize,
     submit_queue_size_threshold: Option<usize>,
     flush_io_size: usize,
+    flush_io_depth: usize,
     clean_region_threshold: Option<usize>,
     eviction_pickers: Vec<Box<dyn EvictionPicker>>,
     reinsertion_picker: Arc<dyn ReinsertionPicker>,
@@ -708,6 +711,7 @@ where
             buffer_pool_size: 16 * 1024 * 1024, // 16 MiB
             submit_queue_size_threshold: None,
             flush_io_size: 128 * 1024, // 128 KiB
+            flush_io_depth: 256,
             clean_region_threshold: None,
             eviction_pickers: vec![Box::new(InvalidRatioPicker::new(0.8)), Box::<FifoPicker>::default()],
             reinsertion_picker: Arc::<RejectAllPicker>::default(),


### PR DESCRIPTION
## What's changed and what's your intention?

> Please explain **IN DETAIL** what the changes are in this PR and why they are needed. :D

As title. To optimize inode lock hold duration. #873 

## Checklist

- [x] I have written the necessary rustdoc comments
- [x] I have added the necessary unit tests and integration tests
- [x] I have passed `make all` (or `make fast` instead if the old tests are not modified) in my local environment.

## Related issues or PRs (optional)
close #873 