### PR TITLE
feat: support hand-mande ser/de and serde by default

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -235,6 +235,7 @@ jobs:
           cargo llvm-cov --no-report run --features "tracing,ot" --example tail_based_tracing
           cargo llvm-cov --no-report run --example equivalent
           cargo llvm-cov --no-report run --example export_metrics_prometheus_hyper
+          cargo llvm-cov --no-report run --example serde
       - name: Generate codecov report
         run: |
           cargo llvm-cov report --lcov --output-path lcov.info

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -46,6 +46,7 @@ thiserror = "2"
 tracing = "0.1"
 prometheus = "0.13"
 mixtrics = "0.0.4"
+criterion = "0.5"
 
 # foyer components
 foyer-common = { version = "0.15.3", path = "foyer-common" }

--- a/Makefile
+++ b/Makefile
@@ -47,6 +47,7 @@ example:
 	cargo run --features "tracing,ot" --example tail_based_tracing
 	cargo run --example equivalent
 	cargo run --example export_metrics_prometheus_hyper
+	cargo run --example serde
 
 full: check-all test-all example machete udeps
 

--- a/examples/Cargo.toml
+++ b/examples/Cargo.toml
@@ -36,6 +36,7 @@ opentelemetry_sdk = { version = "0.26", features = [
   "trace",
 ], optional = true }
 prometheus = { workspace = true }
+serde = { workspace = true }
 tempfile = "3"
 tokio = { version = "1", features = ["rt"] }
 tracing = { workspace = true }
@@ -77,3 +78,7 @@ path = "equivalent.rs"
 [[example]]
 name = "export_metrics_prometheus_hyper"
 path = "export_metrics_prometheus_hyper.rs"
+
+[[example]]
+name = "serde"
+path = "serde.rs"

--- a/examples/serde.rs
+++ b/examples/serde.rs
@@ -1,0 +1,97 @@
+// Copyright 2025 foyer Project Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use std::fmt::Debug;
+
+use foyer::{
+    Deserialize, DirectFsDeviceOptions, Engine, HybridCache, HybridCacheBuilder, HybridCachePolicy, Serialize,
+    StorageValue,
+};
+
+#[derive(Debug, Clone, PartialEq, Eq, serde::Serialize, serde::Deserialize)]
+struct Foo {
+    a: u64,
+    b: String,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+struct Bar {
+    a: u64,
+    b: String,
+}
+
+impl Serialize for Bar {
+    fn serialize(&self, writer: &mut impl std::io::Write) -> std::io::Result<()> {
+        writer.write_all(&self.a.to_le_bytes())?;
+        writer.write_all(&(self.b.len() as u64).to_le_bytes())?;
+        writer.write_all(self.b.as_bytes())?;
+        Ok(())
+    }
+
+    fn estimated_size(&self) -> usize {
+        8 + 8 + self.b.len()
+    }
+}
+
+impl Deserialize for Bar {
+    fn deserialize(reader: &mut impl std::io::Read) -> std::io::Result<Self>
+    where
+        Self: Sized,
+    {
+        let mut buf = [0u8; 8];
+        reader.read_exact(&mut buf)?;
+        let a = u64::from_le_bytes(buf);
+        reader.read_exact(&mut buf)?;
+        let b_len = u64::from_le_bytes(buf) as usize;
+        let bytes = vec![0u8; b_len];
+        let b = String::from_utf8(bytes).map_err(|e| std::io::Error::new(std::io::ErrorKind::Other, e))?;
+        Ok(Self { a, b })
+    }
+}
+
+async fn case<V: StorageValue + Clone + Eq + Debug>(value: V) -> anyhow::Result<()> {
+    let dir = tempfile::tempdir()?;
+
+    let hybrid: HybridCache<u64, V> = HybridCacheBuilder::new()
+        .with_policy(HybridCachePolicy::WriteOnInsertion)
+        .memory(64 * 1024 * 1024)
+        .storage(Engine::Large) // use large object disk cache engine only
+        .with_device_options(DirectFsDeviceOptions::new(dir.path()).with_capacity(256 * 1024 * 1024))
+        .build()
+        .await?;
+
+    hybrid.insert(42, value.clone());
+    assert_eq!(hybrid.get(&42).await?.unwrap().value(), &value);
+
+    Ok(())
+}
+
+#[tokio::main]
+async fn main() -> anyhow::Result<()> {
+    case("The answer to life, the universe, and everything.".to_string()).await?;
+
+    case(Foo {
+        a: 42,
+        b: "The answer to life, the universe, and everything.".to_string(),
+    })
+    .await?;
+
+    case(Bar {
+        a: 42,
+        b: "The answer to life, the universe, and everything.".to_string(),
+    })
+    .await?;
+
+    Ok(())
+}

--- a/examples/serde.rs
+++ b/examples/serde.rs
@@ -15,7 +15,7 @@
 use std::fmt::Debug;
 
 use foyer::{
-    Deserialize, DirectFsDeviceOptions, Engine, HybridCache, HybridCacheBuilder, HybridCachePolicy, Serialize,
+    CodeResult, Decode, DirectFsDeviceOptions, Encode, Engine, HybridCache, HybridCacheBuilder, HybridCachePolicy,
     StorageValue,
 };
 
@@ -31,8 +31,8 @@ struct Bar {
     b: String,
 }
 
-impl Serialize for Bar {
-    fn serialize(&self, writer: &mut impl std::io::Write) -> std::io::Result<()> {
+impl Encode for Bar {
+    fn encode(&self, writer: &mut impl std::io::Write) -> CodeResult<()> {
         writer.write_all(&self.a.to_le_bytes())?;
         writer.write_all(&(self.b.len() as u64).to_le_bytes())?;
         writer.write_all(self.b.as_bytes())?;
@@ -44,8 +44,8 @@ impl Serialize for Bar {
     }
 }
 
-impl Deserialize for Bar {
-    fn deserialize(reader: &mut impl std::io::Read) -> std::io::Result<Self>
+impl Decode for Bar {
+    fn decode(reader: &mut impl std::io::Read) -> CodeResult<Self>
     where
         Self: Sized,
     {

--- a/foyer-common/Cargo.toml
+++ b/foyer-common/Cargo.toml
@@ -22,6 +22,7 @@ mixtrics = { workspace = true }
 parking_lot = { workspace = true }
 pin-project = "1"
 serde = { workspace = true }
+thiserror = { workspace = true }
 
 [dev-dependencies]
 futures-util = { workspace = true }

--- a/foyer-common/Cargo.toml
+++ b/foyer-common/Cargo.toml
@@ -25,9 +25,13 @@ serde = { workspace = true }
 thiserror = { workspace = true }
 
 [dev-dependencies]
+bytes = { version = "1", features = ["serde"] }
+criterion = { workspace = true }
 futures-util = { workspace = true }
 mixtrics = { workspace = true, features = ["test-utils"] }
 rand = { workspace = true }
+serde = { workspace = true }
+serde_bytes = "0.11"
 
 [target.'cfg(madsim)'.dependencies]
 tokio = { package = "madsim-tokio", version = "0.2", features = [
@@ -57,3 +61,7 @@ tracing = ["fastrace/enable"]
 
 [lints]
 workspace = true
+
+[[bench]]
+name = "bench_serde"
+harness = false

--- a/foyer-common/Cargo.toml
+++ b/foyer-common/Cargo.toml
@@ -13,6 +13,7 @@ readme = { workspace = true }
 
 [dependencies]
 ahash = { workspace = true }
+bincode = "1"
 bytes = { workspace = true }
 cfg-if = "1"
 fastrace = { workspace = true }

--- a/foyer-common/benches/bench_serde.rs
+++ b/foyer-common/benches/bench_serde.rs
@@ -1,0 +1,200 @@
+// Copyright 2025 foyer Project Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#![expect(missing_docs)]
+
+use std::time::Instant;
+
+use bytes::{Bytes, BytesMut};
+use criterion::{criterion_group, criterion_main, Bencher, Criterion};
+use foyer_common::code::{Decode, Encode, StorageValue};
+
+const K: usize = 1 << 10;
+const M: usize = 1 << 20;
+
+#[derive(Debug, serde::Serialize, serde::Deserialize)]
+pub struct VecU8ValueSerde(Vec<u8>);
+
+impl VecU8ValueSerde {
+    pub fn new(size: usize) -> Self {
+        let mut v = vec![0; size];
+        rand::fill(&mut v[..]);
+        Self(v)
+    }
+}
+
+#[derive(Debug, serde::Serialize, serde::Deserialize)]
+pub struct VecU8ValueSerdeBytes(#[serde(with = "serde_bytes")] Vec<u8>);
+
+impl VecU8ValueSerdeBytes {
+    pub fn new(size: usize) -> Self {
+        let mut v = vec![0; size];
+        rand::fill(&mut v[..]);
+        Self(v)
+    }
+}
+
+#[derive(Debug)]
+pub struct VecU8Value(Vec<u8>);
+
+impl VecU8Value {
+    pub fn new(size: usize) -> Self {
+        let mut v = vec![0; size];
+        rand::fill(&mut v[..]);
+        Self(v)
+    }
+}
+
+impl Encode for VecU8Value {
+    fn encode(&self, writer: &mut impl std::io::Write) -> foyer_common::code::CodeResult<()> {
+        writer.write_all(&self.0.len().to_le_bytes())?;
+        writer.write_all(&self.0)?;
+        Ok(())
+    }
+
+    fn estimated_size(&self) -> usize {
+        self.0.len()
+    }
+}
+
+impl Decode for VecU8Value {
+    #[expect(clippy::uninit_vec)]
+    fn decode(reader: &mut impl std::io::Read) -> std::result::Result<Self, foyer_common::code::CodeError>
+    where
+        Self: Sized,
+    {
+        let mut buf = [0u8; 8];
+        reader.read_exact(&mut buf)?;
+        let len = u64::from_le_bytes(buf) as usize;
+        let mut v = Vec::with_capacity(len);
+        unsafe { v.set_len(len) };
+        reader.read_exact(&mut v)?;
+        Ok(Self(v))
+    }
+}
+
+#[derive(Debug, serde::Serialize, serde::Deserialize)]
+pub struct BytesValueSerde(Bytes);
+
+impl BytesValueSerde {
+    pub fn new(size: usize) -> Self {
+        let mut v = vec![0; size];
+        rand::fill(&mut v[..]);
+        Self(Bytes::from(v))
+    }
+}
+
+#[derive(Debug)]
+pub struct BytesValue(Bytes);
+
+impl BytesValue {
+    pub fn new(size: usize) -> Self {
+        let mut v = vec![0; size];
+        rand::fill(&mut v[..]);
+        Self(Bytes::from(v))
+    }
+}
+
+impl Encode for BytesValue {
+    fn encode(&self, writer: &mut impl std::io::Write) -> foyer_common::code::CodeResult<()> {
+        writer.write_all(&self.0.len().to_le_bytes())?;
+        writer.write_all(&self.0)?;
+        Ok(())
+    }
+
+    fn estimated_size(&self) -> usize {
+        self.0.len()
+    }
+}
+
+impl Decode for BytesValue {
+    fn decode(reader: &mut impl std::io::Read) -> std::result::Result<Self, foyer_common::code::CodeError>
+    where
+        Self: Sized,
+    {
+        let mut buf = [0u8; 8];
+        reader.read_exact(&mut buf)?;
+        let len = u64::from_le_bytes(buf) as usize;
+        let mut v = BytesMut::with_capacity(len);
+        unsafe { v.set_len(len) };
+        reader.read_exact(&mut v)?;
+        Ok(Self(v.freeze()))
+    }
+}
+
+fn encode<V: StorageValue>(b: &mut Bencher, v: V, size: usize) {
+    b.iter_custom(|iters| {
+        let mut buf = vec![0; size * 2];
+        let start = Instant::now();
+        for _ in 0..iters {
+            v.encode(&mut &mut buf[..]).unwrap();
+        }
+        start.elapsed()
+    });
+}
+
+fn decode<V: StorageValue>(b: &mut Bencher, v: V, size: usize) {
+    b.iter_custom(|iters| {
+        let mut buf = vec![0; size * 2];
+        v.encode(&mut &mut buf[..]).unwrap();
+        let start = Instant::now();
+        for _ in 0..iters {
+            V::decode(&mut &buf[..]).unwrap();
+        }
+        start.elapsed()
+    });
+}
+
+fn bench_encode(c: &mut Criterion) {
+    for (s, size) in [("64K", 64 * K), ("4M", 4 * M)] {
+        c.bench_function(&format!("Vec<u8> value encode - {}", s), |b| {
+            encode(b, VecU8Value::new(size), size);
+        });
+        c.bench_function(&format!("Vec<u8> value serde encode - {}", s), |b| {
+            encode(b, VecU8ValueSerde::new(size), size);
+        });
+        c.bench_function(&format!("Vec<u8> value serde_bytes encode - {}", s), |b| {
+            encode(b, VecU8ValueSerdeBytes::new(size), size);
+        });
+        c.bench_function(&format!("Bytes value encode - {}", s), |b| {
+            encode(b, BytesValue::new(size), size);
+        });
+        c.bench_function(&format!("Bytes value serde encode - {}", s), |b| {
+            encode(b, BytesValueSerde::new(size), size);
+        });
+    }
+}
+
+fn bench_decode(c: &mut Criterion) {
+    for (s, size) in [("64K", 64 * K), ("4M", 4 * M)] {
+        c.bench_function(&format!("Vec<u8> value decode - {}", s), |b| {
+            decode(b, VecU8Value::new(size), size);
+        });
+        c.bench_function(&format!("Vec<u8> value serde decode - {}", s), |b| {
+            decode(b, VecU8ValueSerde::new(size), size);
+        });
+        c.bench_function(&format!("Vec<u8> value serde_bytes decode - {}", s), |b| {
+            decode(b, VecU8ValueSerdeBytes::new(size), size);
+        });
+        c.bench_function(&format!("Bytes value decode - {}", s), |b| {
+            decode(b, BytesValue::new(size), size);
+        });
+        c.bench_function(&format!("Bytes value serde decode - {}", s), |b| {
+            decode(b, BytesValueSerde::new(size), size);
+        });
+    }
+}
+
+criterion_group!(benches, bench_encode, bench_decode);
+criterion_main!(benches);

--- a/foyer-common/src/code.rs
+++ b/foyer-common/src/code.rs
@@ -22,56 +22,102 @@ pub trait Value: Send + Sync + 'static {}
 impl<T: Send + Sync + 'static + std::hash::Hash + Eq> Key for T {}
 impl<T: Send + Sync + 'static> Value for T {}
 
-/// Key trait for the disk cache.
-pub trait StorageKey: Key + Serialize + Deserialize {}
-impl<T> StorageKey for T where T: Key + Serialize + Deserialize {}
-
-/// Value trait for the disk cache.
-pub trait StorageValue: Value + 'static + Serialize + Deserialize {}
-impl<T> StorageValue for T where T: Value + Serialize + Deserialize {}
-
 /// Hash builder trait.
 pub trait HashBuilder: BuildHasher + Send + Sync + 'static {}
 impl<T> HashBuilder for T where T: BuildHasher + Send + Sync + 'static {}
 
-/// Serialization trait for key and value.
-pub trait Serialize {
-    /// Serialize the object into a writer.
-    fn serialize(&self, writer: &mut impl std::io::Write) -> std::io::Result<()>;
+/// Code error.
+#[derive(Debug, thiserror::Error)]
+pub enum CodeError {
+    /// The buffer size is not enough to hold the serialized data.
+    #[error("exceed size limit")]
+    SizeLimit,
+    /// Other std io error.
+    #[error("io error: {0}")]
+    Io(std::io::Error),
+    #[error("bincode error: {0}")]
+    /// Other bincode error.
+    Bincode(bincode::Error),
+}
+
+/// Code Result.
+pub type CodeResult<T> = std::result::Result<T, CodeError>;
+
+impl From<std::io::Error> for CodeError {
+    fn from(err: std::io::Error) -> Self {
+        match err.kind() {
+            std::io::ErrorKind::WriteZero => Self::SizeLimit,
+            _ => Self::Io(err),
+        }
+    }
+}
+
+impl From<bincode::Error> for CodeError {
+    fn from(err: bincode::Error) -> Self {
+        match *err {
+            bincode::ErrorKind::SizeLimit => Self::SizeLimit,
+            bincode::ErrorKind::Io(e) => e.into(),
+            _ => Self::Bincode(err),
+        }
+    }
+}
+
+/// Key trait for the disk cache.
+pub trait StorageKey: Key + Encode + Decode {}
+impl<T> StorageKey for T where T: Key + Encode + Decode {}
+
+/// Value trait for the disk cache.
+pub trait StorageValue: Value + 'static + Encode + Decode {}
+impl<T> StorageValue for T where T: Value + Encode + Decode {}
+
+/// Encode trait for key and value.
+pub trait Encode {
+    /// Encode the object into a writer.
+    fn encode(&self, writer: &mut impl std::io::Write) -> std::result::Result<(), CodeError>;
 
     /// Estimated serialized size of the object.
+    ///
+    /// The estimated serialized size is used by selector between large and small object disk cache engines.
     fn estimated_size(&self) -> usize;
 }
 
-impl<T> Serialize for T
-where
-    T: serde::Serialize + serde::de::DeserializeOwned,
-{
-    fn serialize(&self, writer: &mut impl std::io::Write) -> std::io::Result<()> {
-        // FIXME(MrCroxx): handle cannot write whole buffer.
-        bincode::serialize_into(writer, self).map_err(|e| std::io::Error::new(std::io::ErrorKind::Other, e))
-    }
-
-    fn estimated_size(&self) -> usize {
-        // FIXME(MrCroxx): handle error
-        bincode::serialized_size(self).unwrap() as usize
-    }
-}
-
-/// Deserialization trait for key and value.
-pub trait Deserialize {
-    /// Deserialize the object from a reader.
-    fn deserialize(reader: &mut impl std::io::Read) -> std::io::Result<Self>
+/// Decode trait for key and value.
+pub trait Decode {
+    /// Decode the object from a reader.
+    fn decode(reader: &mut impl std::io::Read) -> std::result::Result<Self, CodeError>
     where
         Self: Sized;
 }
 
-impl<T> Deserialize for T
+impl<T> Encode for T
+where
+    T: serde::Serialize + serde::de::DeserializeOwned,
+{
+    fn encode(&self, writer: &mut impl std::io::Write) -> std::result::Result<(), CodeError> {
+        bincode::serialize_into(writer, self).map_err(CodeError::from)
+    }
+
+    fn estimated_size(&self) -> usize {
+        bincode::serialized_size(self).unwrap() as usize
+    }
+}
+
+impl<T> Decode for T
 where
     T: serde::de::DeserializeOwned,
 {
-    fn deserialize(reader: &mut impl std::io::Read) -> std::io::Result<Self> {
-        // FIXME(MrCroxx): handle cannot read whole buffer.
-        bincode::deserialize_from(reader).map_err(|e| std::io::Error::new(std::io::ErrorKind::Other, e))
+    fn decode(reader: &mut impl std::io::Read) -> std::result::Result<Self, CodeError> {
+        bincode::deserialize_from(reader).map_err(CodeError::from)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_encode_overflow() {
+        let mut buf = [0u8; 4];
+        assert!(matches! {1u64.encode(&mut buf.as_mut()), Err(CodeError::SizeLimit)});
     }
 }

--- a/foyer-storage/src/error.rs
+++ b/foyer-storage/src/error.rs
@@ -17,9 +17,14 @@ use std::{
     ops::Range,
 };
 
+use foyer_common::code::CodeError;
+
 /// Disk cache error type.
 #[derive(thiserror::Error, Debug)]
 pub enum Error {
+    /// Code error.
+    #[error("code error: {0}")]
+    Code(#[from] CodeError),
     /// I/O error.
     #[error("io error: {0}")]
     Io(#[from] std::io::Error),

--- a/foyer-storage/src/serde.rs
+++ b/foyer-storage/src/serde.rs
@@ -112,7 +112,7 @@ impl EntrySerializer {
         W: Write,
     {
         let mut writer = TrackedWriter::new(writer);
-        bincode::serialize_into(&mut writer, &key).map_err(Error::from)?;
+        key.serialize(&mut writer).map_err(Error::from)?;
         Ok(writer.written())
     }
 
@@ -124,21 +124,21 @@ impl EntrySerializer {
         let mut writer = TrackedWriter::new(writer);
         match compression {
             Compression::None => {
-                bincode::serialize_into(&mut writer, &value).map_err(Error::from)?;
+                value.serialize(&mut writer).map_err(Error::from)?;
             }
             Compression::Zstd => {
                 // Do not use `auto_finish()` here, for we will lost `ZeroWrite` error.
                 let mut encoder = zstd::Encoder::new(&mut writer, 0).map_err(Error::from)?;
-                bincode::serialize_into(&mut encoder, &value).map_err(Error::from)?;
+                value.serialize(&mut encoder).map_err(Error::from)?;
                 encoder.finish().map_err(Error::from)?;
             }
             Compression::Lz4 => {
-                let encoder = lz4::EncoderBuilder::new()
+                let mut encoder = lz4::EncoderBuilder::new()
                     .checksum(lz4::ContentChecksum::NoChecksum)
                     .auto_flush(true)
                     .build(&mut writer)
                     .map_err(Error::from)?;
-                bincode::serialize_into(encoder, &value).map_err(Error::from)?;
+                value.serialize(&mut encoder).map_err(Error::from)?;
             }
         }
         Ok(writer.written())
@@ -149,8 +149,7 @@ impl EntrySerializer {
         K: StorageKey,
         V: StorageValue,
     {
-        // `serialized_size` should always return `Ok(..)` without a hard size limit.
-        (bincode::serialized_size(key).unwrap() + bincode::serialized_size(value).unwrap()) as usize
+        key.estimated_size() + value.estimated_size()
     }
 }
 
@@ -194,7 +193,7 @@ impl EntryDeserializer {
     where
         K: StorageKey,
     {
-        bincode::deserialize_from(buf).map_err(Error::from)
+        K::deserialize(&mut &buf[..]).map_err(Error::from)
     }
 
     #[fastrace::trace(name = "foyer::storage::serde::deserialize_value")]
@@ -203,14 +202,14 @@ impl EntryDeserializer {
         V: StorageValue,
     {
         match compression {
-            Compression::None => bincode::deserialize_from(buf).map_err(Error::from),
+            Compression::None => V::deserialize(&mut &buf[..]).map_err(Error::from),
             Compression::Zstd => {
-                let decoder = zstd::Decoder::new(buf).map_err(Error::from)?;
-                bincode::deserialize_from(decoder).map_err(Error::from)
+                let mut decoder = zstd::Decoder::new(buf).map_err(Error::from)?;
+                V::deserialize(&mut decoder).map_err(Error::from)
             }
             Compression::Lz4 => {
-                let decoder = lz4::Decoder::new(buf).map_err(Error::from)?;
-                bincode::deserialize_from(decoder).map_err(Error::from)
+                let mut decoder = lz4::Decoder::new(buf).map_err(Error::from)?;
+                V::deserialize(&mut decoder).map_err(Error::from)
             }
         }
     }

--- a/foyer/src/prelude.rs
+++ b/foyer/src/prelude.rs
@@ -15,7 +15,7 @@
 pub use crate::{
     common::{
         buf::{BufExt, BufMutExt},
-        code::{Deserialize, Key, Serialize, StorageKey, StorageValue, Value},
+        code::{CodeError, CodeResult, Decode, Encode, Key, StorageKey, StorageValue, Value},
         event::{Event, EventListener},
         range::RangeBoundsExt,
         tracing::TracingOptions,

--- a/foyer/src/prelude.rs
+++ b/foyer/src/prelude.rs
@@ -15,7 +15,7 @@
 pub use crate::{
     common::{
         buf::{BufExt, BufMutExt},
-        code::{Key, StorageKey, StorageValue, Value},
+        code::{Deserialize, Key, Serialize, StorageKey, StorageValue, Value},
         event::{Event, EventListener},
         range::RangeBoundsExt,
         tracing::TracingOptions,


### PR DESCRIPTION
## What's changed and what's your intention?

> Please explain **IN DETAIL** what the changes are in this PR and why they are needed. :D

Refactor key and value encoding and decoding with self-defined trait `Encode` and `Decode` to make it possible to make `serde` optional in the future.

TODO: 

- [x] Refine error handling.
- ~Feature to control if enable default serde support to prevent from impl conflict.~ #923 
- [x] Bytes serde benchmark.

## Checklist

- [x] I have written the necessary rustdoc comments
- [x] I have added the necessary unit tests and integration tests
- [x] I have passed `make all` (or `make fast` instead if the old tests are not modified) in my local environment.

## Related issues or PRs (optional)
close #919 