### PR TITLE
fix: fix panic if buffer_pool_size / flushers is not 4K aligned (#947)

### DIFF
--- a/foyer-storage/src/large/flusher.rs
+++ b/foyer-storage/src/large/flusher.rs
@@ -159,6 +159,9 @@ where
         let (tx, rx) = flume::unbounded();
 
         let io_buffer_size = config.buffer_pool_size / config.flushers;
+        let io_buffer_size = bits::align_down(PAGE, io_buffer_size);
+        assert!(io_buffer_size > 0);
+
         bits::assert_aligned(PAGE, io_buffer_size);
         bits::assert_aligned(PAGE, config.blob_index_size);
 

--- a/foyer-storage/src/store.rs
+++ b/foyer-storage/src/store.rs
@@ -937,3 +937,27 @@ where
         self
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use foyer_memory::CacheBuilder;
+
+    use super::*;
+
+    #[tokio::test]
+    async fn test_build_with_unaligned_buffer_pool_size() {
+        let dir = tempfile::tempdir().unwrap();
+        let metrics = Arc::new(Metrics::noop());
+        let memory: Cache<u64, u64> = CacheBuilder::new(10).build();
+        let _ = StoreBuilder::new("test", memory, metrics, Engine::Large)
+            .with_device_options(DirectFsDeviceOptions::new(dir.path()))
+            .with_large_object_disk_cache_options(
+                LargeEngineOptions::new()
+                    .with_flushers(3)
+                    .with_buffer_pool_size(128 * 1024 * 1024),
+            )
+            .build()
+            .await
+            .unwrap();
+    }
+}


### PR DESCRIPTION
## What's changed and what's your intention?

> Please explain **IN DETAIL** what the changes are in this PR and why they are needed. :D

As title.

## Checklist

- [x] I have written the necessary rustdoc comments
- [x] I have added the necessary unit tests and integration tests
- [x] I have passed `make all` (or `make fast` instead if the old tests are not modified) in my local environment.

## Related issues or PRs (optional)
#945