### PR TITLE
refactor: refine flush on close to mitigate burst

### DIFF
--- a/foyer-storage/src/engine.rs
+++ b/foyer-storage/src/engine.rs
@@ -26,7 +26,7 @@ use crate::{
         either::{Either, EitherConfig, Selection, Selector},
         noop::Noop,
     },
-    Statistics, Storage,
+    Statistics, Storage, Throttle,
 };
 
 pub struct SizeSelector<K, V>
@@ -226,7 +226,7 @@ where
         }
     }
 
-    fn throttle(&self) -> &crate::Throttle {
+    fn throttle(&self) -> &Throttle {
         match self {
             EngineEnum::Noop(storage) => storage.throttle(),
             EngineEnum::Large(storage) => storage.throttle(),

--- a/foyer-storage/src/picker/utils.rs
+++ b/foyer-storage/src/picker/utils.rs
@@ -115,6 +115,7 @@ struct IoThrottlerPickerInner {
     target: IoThrottlerTarget,
 }
 
+/// Target of the io throttler.
 #[derive(Debug, Clone, PartialEq, Eq)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub enum IoThrottlerTarget {
@@ -148,7 +149,6 @@ impl IoThrottlerPicker {
             ios_last: AtomicUsize::default(),
             target,
         };
-
         Self { inner: Arc::new(inner) }
     }
 

--- a/foyer-storage/src/prelude.rs
+++ b/foyer-storage/src/prelude.rs
@@ -20,7 +20,10 @@ pub use crate::{
         Dev, DevConfig, DevExt, IopsCounter, Throttle,
     },
     error::{Error, Result},
-    io::buffer::{IoBuf, IoBufMut, IoBuffer, OwnedIoSlice, OwnedSlice, SharedIoSlice},
+    io::{
+        buffer::{IoBuf, IoBufMut, IoBuffer, OwnedIoSlice, OwnedSlice, SharedIoSlice},
+        throttle::IoThrottler,
+    },
     large::{
         recover::RecoverMode,
         tombstone::{TombstoneLogConfig, TombstoneLogConfigBuilder},
@@ -28,7 +31,7 @@ pub use crate::{
     picker::{
         utils::{
             AdmitAllPicker, ChainedAdmissionPicker, ChainedAdmissionPickerBuilder, FifoPicker, InvalidRatioPicker,
-            IoThrottlerPicker, RejectAllPicker,
+            IoThrottlerPicker, IoThrottlerTarget, RejectAllPicker,
         },
         AdmissionPicker, EvictionPicker, Pick, ReinsertionPicker,
     },

--- a/foyer-storage/src/store.rs
+++ b/foyer-storage/src/store.rs
@@ -58,7 +58,7 @@ use crate::{
         Storage,
     },
     ChainedAdmissionPickerBuilder, Dev, DevExt, DirectFileDeviceOptions, DirectFsDeviceOptions, IoThrottlerPicker,
-    Pick,
+    Pick, Throttle,
 };
 
 /// Load result.
@@ -264,6 +264,11 @@ where
         self.inner.engine.statistics()
     }
 
+    /// Get the io throttle of the disk cache.
+    pub fn throttle(&self) -> &Throttle {
+        self.inner.engine.throttle()
+    }
+
     /// Get the runtime.
     pub fn runtime(&self) -> &Runtime {
         &self.inner.runtime
@@ -272,6 +277,11 @@ where
     /// Wait for the ongoing flush and reclaim tasks to finish.
     pub async fn wait(&self) {
         self.inner.engine.wait().await
+    }
+
+    /// Return the estimated serialized size of the entry.
+    pub fn entry_estimated_size(&self, key: &K, value: &V) -> usize {
+        EntrySerializer::estimated_size(key, value)
     }
 
     /// Get the load throttle switch for the disk cache.
@@ -924,9 +934,9 @@ where
     /// If the total entry estimated size in the submit queue exceeds the threshold, the further entries will be
     /// ignored.
     ///
-    /// Default: `buffer_pool_size`` * 2.
-    pub fn with_submit_queue_size_threshold(mut self, buffer_pool_size: usize) -> Self {
-        self.buffer_pool_size = buffer_pool_size;
+    /// Default: `buffer_pool_size` * 2.
+    pub fn with_submit_queue_size_threshold(mut self, submit_queue_size_threshold: usize) -> Self {
+        self.submit_queue_size_threshold = Some(submit_queue_size_threshold);
         self
     }
 


### PR DESCRIPTION
## What's changed and what's your intention?

> Please explain **IN DETAIL** what the changes are in this PR and why they are needed. :D

The original design cannot handle the burst admission pick on flush.

The new design uses a dedicated io throttle on flush to limit the enqueue rate.

## Checklist

- [x] I have written the necessary rustdoc comments
- [x] I have added the necessary unit tests and integration tests
- [x] I have passed `make all` (or `make fast` instead if the old tests are not modified) in my local environment.

## Related issues or PRs (optional)
#897 #926 