### PR TITLE
refactor: ignore disk write for entries populated from disk

### DIFF
--- a/foyer-memory/src/raw.rs
+++ b/foyer-memory/src/raw.rs
@@ -1131,15 +1131,18 @@ where
                         return Diversion { target: Err(e), store };
                     }
                 };
-                let location = if let Some(store) = store.as_ref() {
-                    if store.throttled {
+
+                let location = match store.as_ref() {
+                    Some(ctx) => match ctx.throttled {
+                        true => CacheLocation::InMem,
+                        false => location,
+                    },
+                    None => {
+                        // No fetch context indicates that the entry is populated. Don't need to write back to disk cache again.
                         CacheLocation::InMem
-                    } else {
-                        location
                     }
-                } else {
-                    location
                 };
+
                 let entry =
                     cache.insert_advanced(key, value, hint, location, matches! {location, CacheLocation::OnDisk});
                 Diversion {

--- a/foyer-memory/src/raw.rs
+++ b/foyer-memory/src/raw.rs
@@ -1138,7 +1138,8 @@ where
                         false => location,
                     },
                     None => {
-                        // No fetch context indicates that the entry is populated. Don't need to write back to disk cache again.
+                        // No fetch context indicates that the entry is populated.
+                        // Don't need to write back to disk cache again.
                         CacheLocation::InMem
                     }
                 };


### PR DESCRIPTION
## What's changed and what's your intention?

> Please explain **IN DETAIL** what the changes are in this PR and why they are needed. :D

As the title.

After this PR, the old but hot entries will be evicted by FIFO region eviction policy. #970 propose to make the region eviction policy better.

## Checklist

- [x] I have written the necessary rustdoc comments
- [x] I have added the necessary unit tests and integration tests
- [x] I have passed `make all` (or `make fast` instead if the old tests are not modified) in my local environment.

## Related issues or PRs (optional)
close #971