### PR TITLE
feat: skip disk cache insert for young populated entries

### DIFF
--- a/foyer-bench/src/main.rs
+++ b/foyer-bench/src/main.rs
@@ -285,6 +285,9 @@ struct Args {
 
     #[arg(long, default_value_t = false)]
     flush_on_close: bool,
+
+    #[arg(long, default_value_t = 0.1)]
+    lodc_fifo_probation_ratio: f64,
 }
 
 #[derive(Debug)]
@@ -550,7 +553,7 @@ async fn benchmark(args: Args) {
         .with_reclaimers(args.reclaimers)
         .with_eviction_pickers(vec![
             Box::new(InvalidRatioPicker::new(args.invalid_ratio)),
-            Box::<FifoPicker>::default(),
+            Box::new(FifoPicker::new(args.lodc_fifo_probation_ratio)),
         ])
         .with_buffer_pool_size(args.buffer_pool_size.as_u64() as _)
         .with_blob_index_size(args.blob_index_size.as_u64() as _);

--- a/foyer-common/src/metrics.rs
+++ b/foyer-common/src/metrics.rs
@@ -70,6 +70,7 @@ pub struct Metrics {
     pub storage_entry_deserialize_duration: BoxedHistogram,
 
     pub storage_lodc_indexer_conflict: BoxedCounter,
+    pub storage_lodc_enqueue_skip: BoxedCounter,
     pub storage_lodc_buffer_efficiency: BoxedHistogram,
     pub storage_lodc_recover_duration: BoxedHistogram,
 
@@ -256,6 +257,7 @@ impl Metrics {
 
         let storage_lodc_indexer_conflict =
             foyer_storage_lodc_op_total.counter(&[name.clone(), "indexer_conflict".into()]);
+        let storage_lodc_enqueue_skip = foyer_storage_lodc_op_total.counter(&[name.clone(), "enqueue_skip".into()]);
         let storage_lodc_buffer_efficiency = foyer_storage_lodc_buffer_efficiency.histogram(&[name.clone()]);
         let storage_lodc_recover_duration = foyer_storage_lodc_recover_duration.histogram(&[name.clone()]);
 
@@ -326,6 +328,7 @@ impl Metrics {
             storage_entry_serialize_duration,
             storage_entry_deserialize_duration,
             storage_lodc_indexer_conflict,
+            storage_lodc_enqueue_skip,
             storage_lodc_buffer_efficiency,
             storage_lodc_recover_duration,
 

--- a/foyer-common/src/properties.rs
+++ b/foyer-common/src/properties.rs
@@ -66,13 +66,29 @@ impl Default for Location {
     }
 }
 
+/// Entry age in the disk cache. Used by hybrid cache.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum Age {
+    /// THe entry is still young and will be reserved in the disk cache for a while.
+    Young,
+    /// The entry is old any will be eviction from the disk cache soon.
+    Old,
+}
+
+/// Source context for populated entry.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct Populated {
+    /// The age of the entry.
+    pub age: Age,
+}
+
 /// Entry source used by hybrid cache.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum Source {
     /// Comes from outer system of foyer.
     Outer,
     /// Populated from the disk cache.
-    Populated,
+    Populated(Populated),
 }
 
 impl Default for Source {

--- a/foyer-storage/src/engine.rs
+++ b/foyer-storage/src/engine.rs
@@ -29,7 +29,7 @@ use crate::{
         either::{Either, EitherConfig, Selection, Selector},
         noop::Noop,
     },
-    Statistics, Storage, Throttle,
+    Load, Statistics, Storage, Throttle,
 };
 
 pub struct SizeSelector<K, V, P>
@@ -205,7 +205,7 @@ where
     }
 
     #[auto_enum(Future)]
-    fn load(&self, hash: u64) -> impl Future<Output = Result<Option<(Self::Key, Self::Value)>>> + Send + 'static {
+    fn load(&self, hash: u64) -> impl Future<Output = Result<Load<Self::Key, Self::Value>>> + Send + 'static {
         match self {
             EngineEnum::Noop(storage) => storage.load(hash),
             EngineEnum::Large(storage) => storage.load(hash),

--- a/foyer-storage/src/large/generic.rs
+++ b/foyer-storage/src/large/generic.rs
@@ -322,6 +322,11 @@ where
             return;
         }
 
+        tracing::trace!(
+            hash = piece.hash(),
+            source = ?piece.properties().source().unwrap_or_default(),
+            "[lodc]: enqueue"
+        );
         match piece.properties().source().unwrap_or_default() {
             Source::Populated(Populated { age }) => match age {
                 Age::Young => {

--- a/foyer-storage/src/large/generic.rs
+++ b/foyer-storage/src/large/generic.rs
@@ -29,7 +29,7 @@ use foyer_common::{
     bits,
     code::{StorageKey, StorageValue},
     metrics::Metrics,
-    properties::Properties,
+    properties::{Age, Populated, Properties, Source},
 };
 use foyer_memory::Piece;
 use futures_util::future::{join_all, try_join_all};
@@ -59,7 +59,7 @@ use crate::{
     serde::EntryDeserializer,
     statistics::Statistics,
     storage::Storage,
-    Throttle,
+    Load, Throttle,
 };
 
 pub struct GenericLargeStorageConfig<K, V>
@@ -322,6 +322,18 @@ where
             return;
         }
 
+        match piece.properties().source().unwrap_or_default() {
+            Source::Populated(Populated { age }) => match age {
+                Age::Young => {
+                    // skip write lodc if the entry is still young
+                    self.inner.metrics.storage_lodc_enqueue_skip.increase(1);
+                    return;
+                }
+                Age::Old => {}
+            },
+            Source::Outer => {}
+        }
+
         if self.inner.submit_queue_size.load(Ordering::Relaxed) > self.inner.submit_queue_size_threshold {
             self.inner.metrics.storage_queue_channel_overflow.increase(1);
             return;
@@ -336,12 +348,12 @@ where
         });
     }
 
-    fn load(&self, hash: u64) -> impl Future<Output = Result<Option<(K, V)>>> + Send + 'static {
+    fn load(&self, hash: u64) -> impl Future<Output = Result<Load<K, V>>> + Send + 'static {
         let now = Instant::now();
 
-        let device = self.inner.device.clone();
         let indexer = self.inner.indexer.clone();
         let metrics = self.inner.metrics.clone();
+        let region_manager = self.inner.region_manager.clone();
 
         async move {
             let addr = match indexer.get(hash) {
@@ -349,14 +361,15 @@ where
                 None => {
                     metrics.storage_miss.increase(1);
                     metrics.storage_miss_duration.record(now.elapsed().as_secs_f64());
-                    return Ok(None);
+                    return Ok(Load::Miss);
                 }
             };
 
             tracing::trace!(hash, ?addr, "[lodc]: load");
 
+            let region = region_manager.region(addr.region);
             let buf = IoBuffer::new(bits::align_up(PAGE, addr.len as _));
-            let (buf, res) = device.read(buf, addr.region, addr.offset as _).await;
+            let (buf, res) = region.read(buf, addr.offset as _).await;
             match res {
                 Ok(_) => {}
                 Err(e @ Error::InvalidIoRange { .. }) => {
@@ -364,7 +377,7 @@ where
                     indexer.remove(hash);
                     metrics.storage_miss.increase(1);
                     metrics.storage_miss_duration.record(now.elapsed().as_secs_f64());
-                    return Ok(None);
+                    return Ok(Load::Miss);
                 }
                 Err(e) => {
                     tracing::error!(hash, ?addr, ?e, "[lodc load]: load error");
@@ -389,7 +402,7 @@ where
                     indexer.remove(hash);
                     metrics.storage_miss.increase(1);
                     metrics.storage_miss_duration.record(now.elapsed().as_secs_f64());
-                    return Ok(None);
+                    return Ok(Load::Miss);
                 }
                 Err(e) => {
                     tracing::error!(hash, ?addr, ?e, "[lodc load]: load error");
@@ -398,7 +411,7 @@ where
                 }
             };
 
-            let (k, v) = {
+            let (key, value) = {
                 let now = Instant::now();
                 let res = match EntryDeserializer::deserialize::<K, V>(
                     &buf[EntryHeader::serialized_len()..],
@@ -423,7 +436,7 @@ where
                         metrics.storage_miss.increase(1);
                         metrics.storage_miss_duration.record(now.elapsed().as_secs_f64());
                         metrics.storage_error.increase(1);
-                        return Ok(None);
+                        return Ok(Load::Miss);
                     }
                     Err(e) => {
                         tracing::error!(hash, ?addr, ?header, ?e, "[lodc load]: load error");
@@ -440,7 +453,16 @@ where
             metrics.storage_hit.increase(1);
             metrics.storage_hit_duration.record(now.elapsed().as_secs_f64());
 
-            Ok(Some((k, v)))
+            let age = match region.stats().probation.load(Ordering::Relaxed) {
+                true => Age::Old,
+                false => Age::Young,
+            };
+
+            Ok(Load::Entry {
+                key,
+                value,
+                populated: Populated { age },
+            })
         }
         .in_span(Span::enter_with_local_parent("foyer::storage::large::generic::load"))
     }
@@ -546,7 +568,7 @@ where
         self.enqueue(piece, estimated_size)
     }
 
-    fn load(&self, hash: u64) -> impl Future<Output = Result<Option<(Self::Key, Self::Value)>>> + Send + 'static {
+    fn load(&self, hash: u64) -> impl Future<Output = Result<Load<Self::Key, Self::Value>>> + Send + 'static {
         self.load(hash)
     }
 
@@ -708,9 +730,9 @@ mod tests {
         store.unhold_flush();
         store.wait().await;
 
-        let r1 = store.load(memory.hash(&1)).await.unwrap().unwrap();
+        let r1 = store.load(memory.hash(&1)).await.unwrap().kv().unwrap();
         assert_eq!(r1, (1, vec![1; 7 * KB]));
-        let r2 = store.load(memory.hash(&2)).await.unwrap().unwrap();
+        let r2 = store.load(memory.hash(&2)).await.unwrap().kv().unwrap();
         assert_eq!(r2, (2, vec![2; 3 * KB]));
 
         // [ [e1, e2], [e3, e4], [], [] ]
@@ -722,13 +744,13 @@ mod tests {
         store.unhold_flush();
         store.wait().await;
 
-        let r1 = store.load(memory.hash(&1)).await.unwrap().unwrap();
+        let r1 = store.load(memory.hash(&1)).await.unwrap().kv().unwrap();
         assert_eq!(r1, (1, vec![1; 7 * KB]));
-        let r2 = store.load(memory.hash(&2)).await.unwrap().unwrap();
+        let r2 = store.load(memory.hash(&2)).await.unwrap().kv().unwrap();
         assert_eq!(r2, (2, vec![2; 3 * KB]));
-        let r3 = store.load(memory.hash(&3)).await.unwrap().unwrap();
+        let r3 = store.load(memory.hash(&3)).await.unwrap().kv().unwrap();
         assert_eq!(r3, (3, vec![3; 7 * KB]));
-        let r4 = store.load(memory.hash(&4)).await.unwrap().unwrap();
+        let r4 = store.load(memory.hash(&4)).await.unwrap().kv().unwrap();
         assert_eq!(r4, (4, vec![4; 2 * KB]));
 
         // [ [e1, e2], [e3, e4], [e5], [] ]
@@ -736,15 +758,15 @@ mod tests {
         enqueue(&store, e5);
         store.wait().await;
 
-        let r1 = store.load(memory.hash(&1)).await.unwrap().unwrap();
+        let r1 = store.load(memory.hash(&1)).await.unwrap().kv().unwrap();
         assert_eq!(r1, (1, vec![1; 7 * KB]));
-        let r2 = store.load(memory.hash(&2)).await.unwrap().unwrap();
+        let r2 = store.load(memory.hash(&2)).await.unwrap().kv().unwrap();
         assert_eq!(r2, (2, vec![2; 3 * KB]));
-        let r3 = store.load(memory.hash(&3)).await.unwrap().unwrap();
+        let r3 = store.load(memory.hash(&3)).await.unwrap().kv().unwrap();
         assert_eq!(r3, (3, vec![3; 7 * KB]));
-        let r4 = store.load(memory.hash(&4)).await.unwrap().unwrap();
+        let r4 = store.load(memory.hash(&4)).await.unwrap().kv().unwrap();
         assert_eq!(r4, (4, vec![4; 2 * KB]));
-        let r5 = store.load(memory.hash(&5)).await.unwrap().unwrap();
+        let r5 = store.load(memory.hash(&5)).await.unwrap().kv().unwrap();
         assert_eq!(r5, (5, vec![5; 11 * KB]));
 
         // [ [], [e3, e4], [e5], [e6, e4*] ]
@@ -756,15 +778,15 @@ mod tests {
         store.unhold_flush();
         store.wait().await;
 
-        assert!(store.load(memory.hash(&1)).await.unwrap().is_none());
-        assert!(store.load(memory.hash(&2)).await.unwrap().is_none());
-        let r3 = store.load(memory.hash(&3)).await.unwrap().unwrap();
+        assert!(store.load(memory.hash(&1)).await.unwrap().kv().is_none());
+        assert!(store.load(memory.hash(&2)).await.unwrap().kv().is_none());
+        let r3 = store.load(memory.hash(&3)).await.unwrap().kv().unwrap();
         assert_eq!(r3, (3, vec![3; 7 * KB]));
-        let r4v2 = store.load(memory.hash(&4)).await.unwrap().unwrap();
+        let r4v2 = store.load(memory.hash(&4)).await.unwrap().kv().unwrap();
         assert_eq!(r4v2, (4, vec![!4; 3 * KB]));
-        let r5 = store.load(memory.hash(&5)).await.unwrap().unwrap();
+        let r5 = store.load(memory.hash(&5)).await.unwrap().kv().unwrap();
         assert_eq!(r5, (5, vec![5; 11 * KB]));
-        let r6 = store.load(memory.hash(&6)).await.unwrap().unwrap();
+        let r6 = store.load(memory.hash(&6)).await.unwrap().kv().unwrap();
         assert_eq!(r6, (6, vec![6; 7 * KB]));
 
         store.close().await.unwrap();
@@ -775,15 +797,15 @@ mod tests {
 
         let store = store_for_test(dir.path()).await;
 
-        assert!(store.load(memory.hash(&1)).await.unwrap().is_none());
-        assert!(store.load(memory.hash(&2)).await.unwrap().is_none());
-        let r3 = store.load(memory.hash(&3)).await.unwrap().unwrap();
+        assert!(store.load(memory.hash(&1)).await.unwrap().kv().is_none());
+        assert!(store.load(memory.hash(&2)).await.unwrap().kv().is_none());
+        let r3 = store.load(memory.hash(&3)).await.unwrap().kv().unwrap();
         assert_eq!(r3, (3, vec![3; 7 * KB]));
-        let r4v2 = store.load(memory.hash(&4)).await.unwrap().unwrap();
+        let r4v2 = store.load(memory.hash(&4)).await.unwrap().kv().unwrap();
         assert_eq!(r4v2, (4, vec![!4; 3 * KB]));
-        let r5 = store.load(memory.hash(&5)).await.unwrap().unwrap();
+        let r5 = store.load(memory.hash(&5)).await.unwrap().kv().unwrap();
         assert_eq!(r5, (5, vec![5; 11 * KB]));
-        let r6 = store.load(memory.hash(&6)).await.unwrap().unwrap();
+        let r6 = store.load(memory.hash(&6)).await.unwrap().kv().unwrap();
         assert_eq!(r6, (6, vec![6; 7 * KB]));
     }
 
@@ -804,14 +826,14 @@ mod tests {
 
         for i in 0..9 {
             assert_eq!(
-                store.load(memory.hash(&i)).await.unwrap(),
+                store.load(memory.hash(&i)).await.unwrap().kv(),
                 Some((i, vec![i as u8; 3 * KB]))
             );
         }
 
         store.delete(memory.hash(&3));
         store.wait().await;
-        assert_eq!(store.load(memory.hash(&3)).await.unwrap(), None);
+        assert_eq!(store.load(memory.hash(&3)).await.unwrap().kv(), None);
 
         store.close().await.unwrap();
         drop(store);
@@ -820,24 +842,30 @@ mod tests {
         for i in 0..9 {
             if i != 3 {
                 assert_eq!(
-                    store.load(memory.hash(&i)).await.unwrap(),
+                    store.load(memory.hash(&i)).await.unwrap().kv(),
                     Some((i, vec![i as u8; 3 * KB]))
                 );
             } else {
-                assert_eq!(store.load(memory.hash(&3)).await.unwrap(), None);
+                assert_eq!(store.load(memory.hash(&3)).await.unwrap().kv(), None);
             }
         }
 
         enqueue(&store, es[3].clone());
         store.wait().await;
-        assert_eq!(store.load(memory.hash(&3)).await.unwrap(), Some((3, vec![3; 3 * KB])));
+        assert_eq!(
+            store.load(memory.hash(&3)).await.unwrap().kv(),
+            Some((3, vec![3; 3 * KB]))
+        );
 
         store.close().await.unwrap();
         drop(store);
 
         let store = store_for_test_with_tombstone_log(dir.path(), dir.path().join("test-tombstone-log")).await;
 
-        assert_eq!(store.load(memory.hash(&3)).await.unwrap(), Some((3, vec![3; 3 * KB])));
+        assert_eq!(
+            store.load(memory.hash(&3)).await.unwrap().kv(),
+            Some((3, vec![3; 3 * KB]))
+        );
     }
 
     #[test_log::test(tokio::test)]
@@ -859,14 +887,14 @@ mod tests {
 
         for i in 0..9 {
             assert_eq!(
-                store.load(memory.hash(&i)).await.unwrap(),
+                store.load(memory.hash(&i)).await.unwrap().kv(),
                 Some((i, vec![i as u8; 3 * KB]))
             );
         }
 
         store.delete(memory.hash(&3));
         store.wait().await;
-        assert_eq!(store.load(memory.hash(&3)).await.unwrap(), None);
+        assert_eq!(store.load(memory.hash(&3)).await.unwrap().kv(), None);
 
         store.destroy().await.unwrap();
 
@@ -875,19 +903,25 @@ mod tests {
 
         let store = store_for_test_with_tombstone_log(dir.path(), dir.path().join("test-tombstone-log")).await;
         for i in 0..9 {
-            assert_eq!(store.load(memory.hash(&i)).await.unwrap(), None);
+            assert_eq!(store.load(memory.hash(&i)).await.unwrap().kv(), None);
         }
 
         enqueue(&store, es[3].clone());
         store.wait().await;
-        assert_eq!(store.load(memory.hash(&3)).await.unwrap(), Some((3, vec![3; 3 * KB])));
+        assert_eq!(
+            store.load(memory.hash(&3)).await.unwrap().kv(),
+            Some((3, vec![3; 3 * KB]))
+        );
 
         store.close().await.unwrap();
         drop(store);
 
         let store = store_for_test_with_tombstone_log(dir.path(), dir.path().join("test-tombstone-log")).await;
 
-        assert_eq!(store.load(memory.hash(&3)).await.unwrap(), Some((3, vec![3; 3 * KB])));
+        assert_eq!(
+            store.load(memory.hash(&3)).await.unwrap().kv(),
+            Some((3, vec![3; 3 * KB]))
+        );
     }
 
     // FIXME(MrCroxx): Move the admission test to store level.
@@ -930,7 +964,7 @@ mod tests {
         }
 
         for i in 0..9 {
-            let r = store.load(memory.hash(&i)).await.unwrap().unwrap();
+            let r = store.load(memory.hash(&i)).await.unwrap().kv().unwrap();
             assert_eq!(r, (i, vec![i as u8; 3 * KB]));
         }
 
@@ -943,7 +977,7 @@ mod tests {
         }
         let mut res = vec![];
         for i in 0..11 {
-            res.push(store.load(memory.hash(&i)).await.unwrap());
+            res.push(store.load(memory.hash(&i)).await.unwrap().kv());
         }
         assert_eq!(
             res,
@@ -971,7 +1005,7 @@ mod tests {
         let mut res = vec![];
         for i in 0..12 {
             tracing::trace!("==========> {i}");
-            res.push(store.load(memory.hash(&i)).await.unwrap());
+            res.push(store.load(memory.hash(&i)).await.unwrap().kv());
         }
         assert_eq!(
             res,
@@ -1005,7 +1039,7 @@ mod tests {
         }
         let mut res = vec![];
         for i in 0..15 {
-            res.push(store.load(memory.hash(&i)).await.unwrap());
+            res.push(store.load(memory.hash(&i)).await.unwrap().kv());
         }
         assert_eq!(
             res,
@@ -1042,7 +1076,7 @@ mod tests {
         store.wait().await;
 
         // check entry 1
-        let r1 = store.load(memory.hash(&1)).await.unwrap().unwrap();
+        let r1 = store.load(memory.hash(&1)).await.unwrap().kv().unwrap();
         assert_eq!(r1, (1, vec![1; 7 * KB]));
 
         // corrupt entry and header
@@ -1065,6 +1099,6 @@ mod tests {
             }
         }
 
-        assert!(store.load(memory.hash(&1)).await.unwrap().is_none());
+        assert!(store.load(memory.hash(&1)).await.unwrap().kv().is_none());
     }
 }

--- a/foyer-storage/src/large/scanner.rs
+++ b/foyer-storage/src/large/scanner.rs
@@ -109,7 +109,6 @@ mod tests {
             buffer::{BlobEntryIndex, BlobIndex, BlobPart, Buffer, SplitCtx, Splitter},
             serde::Sequence,
         },
-        region::RegionStats,
         Compression, DirectFsDeviceOptions, Runtime,
     };
 
@@ -208,10 +207,7 @@ mod tests {
 
         async fn extract(dev: &MonitoredDevice, region: RegionId) -> Vec<EntryInfo> {
             let mut infos = vec![];
-            let mut scanner = RegionScanner::new(
-                Region::new_for_test(region, dev.clone(), Arc::<RegionStats>::default()),
-                BLOB_INDEX_SIZE,
-            );
+            let mut scanner = RegionScanner::new(Region::new_for_test(region, dev.clone()), BLOB_INDEX_SIZE);
             while let Some(mut es) = scanner.next().await.unwrap() {
                 infos.append(&mut es);
             }

--- a/foyer-storage/src/picker/mod.rs
+++ b/foyer-storage/src/picker/mod.rs
@@ -14,7 +14,7 @@
 
 use std::{collections::HashMap, fmt::Debug, ops::Range, sync::Arc, time::Duration};
 
-use crate::{device::RegionId, region::RegionStats, statistics::Statistics};
+use crate::{device::RegionId, statistics::Statistics, RegionStats};
 
 /// Pick result for admission pickers and reinsertion pickers.
 #[derive(Debug, Clone, Copy)]

--- a/foyer-storage/src/prelude.rs
+++ b/foyer-storage/src/prelude.rs
@@ -35,6 +35,7 @@ pub use crate::{
         },
         AdmissionPicker, EvictionPicker, Pick, ReinsertionPicker,
     },
+    region::RegionStats,
     runtime::Runtime,
     statistics::Statistics,
     storage::{either::Order, Storage},

--- a/foyer-storage/src/storage/mod.rs
+++ b/foyer-storage/src/storage/mod.rs
@@ -23,7 +23,7 @@ use foyer_common::{
 };
 use foyer_memory::Piece;
 
-use crate::{error::Result, Statistics, Throttle};
+use crate::{error::Result, Load, Statistics, Throttle};
 
 /// The storage trait for the disk cache storage engine.
 pub trait Storage: Send + Sync + 'static + Clone + Debug {
@@ -54,7 +54,7 @@ pub trait Storage: Send + Sync + 'static + Clone + Debug {
     /// `load` may return a false-positive result on entry key hash collision. It's the caller's responsibility to
     /// check if the returned key matches the given key.
     #[must_use]
-    fn load(&self, hash: u64) -> impl Future<Output = Result<Option<(Self::Key, Self::Value)>>> + Send + 'static;
+    fn load(&self, hash: u64) -> impl Future<Output = Result<Load<Self::Key, Self::Value>>> + Send + 'static;
 
     /// Delete the cache entry with the given key from the disk cache.
     fn delete(&self, hash: u64);

--- a/foyer-storage/tests/storage_fuzzy_test.rs
+++ b/foyer-storage/tests/storage_fuzzy_test.rs
@@ -53,7 +53,7 @@ async fn test_store(
     let remains = recorder.remains();
 
     for i in 0..INSERTS as u64 * (LOOPS + 1) as u64 {
-        let value = store.load(&i).await.unwrap().entry().map(|(_, v)| v);
+        let value = store.load(&i).await.unwrap().kv().map(|(_, v)| v);
         if remains.contains(&i) {
             assert_eq!(value, Some(vec![i as u8; 1 * KB]));
         } else {
@@ -69,7 +69,7 @@ async fn test_store(
         let remains = recorder.remains();
 
         for i in 0..INSERTS as u64 * (LOOPS + 1) as u64 {
-            let value = store.load(&i).await.unwrap().entry().map(|(_, v)| v);
+            let value = store.load(&i).await.unwrap().kv().map(|(_, v)| v);
             if remains.contains(&i) {
                 assert_eq!(value, Some(vec![i as u8; 1 * KB]), "value mismatch, loop: {l}, i: {i}");
             } else {
@@ -89,7 +89,7 @@ async fn test_store(
         let remains = recorder.remains();
 
         for i in 0..INSERTS as u64 * (LOOPS + 1) as u64 {
-            let value = store.load(&i).await.unwrap().entry().map(|(_, v)| v);
+            let value = store.load(&i).await.unwrap().kv().map(|(_, v)| v);
             if remains.contains(&i) {
                 assert_eq!(value, Some(vec![i as u8; 1 * KB]));
             } else {

--- a/foyer/src/prelude.rs
+++ b/foyer/src/prelude.rs
@@ -17,7 +17,7 @@ pub use crate::{
         buf::{BufExt, BufMutExt},
         code::{Code, CodeError, CodeResult, Key, StorageKey, StorageValue, Value},
         event::{Event, EventListener},
-        properties::{Hint, Location, Source},
+        properties::{Age, Hint, Location, Source},
         tracing::TracingOptions,
         utils::{option::OptionExt, range::RangeBoundsExt, scope::Scope},
     },
@@ -34,7 +34,7 @@ pub use crate::{
         AdmissionPicker, AdmitAllPicker, ChainedAdmissionPicker, ChainedAdmissionPickerBuilder, Compression, Dev,
         DevConfig, DevExt, DirectFileDevice, DirectFileDeviceOptions, DirectFsDevice, DirectFsDeviceOptions, Engine,
         EvictionPicker, FifoPicker, InvalidRatioPicker, IopsCounter, LargeEngineOptions, Load, Pick, RecoverMode,
-        ReinsertionPicker, RejectAllPicker, Runtime, RuntimeOptions, SmallEngineOptions, Statistics, Storage, Store,
-        StoreBuilder, Throttle, TokioRuntimeOptions, TombstoneLogConfigBuilder,
+        RegionStats, ReinsertionPicker, RejectAllPicker, Runtime, RuntimeOptions, SmallEngineOptions, Statistics,
+        Storage, Store, StoreBuilder, Throttle, TokioRuntimeOptions, TombstoneLogConfigBuilder,
     },
 };


### PR DESCRIPTION
## What's changed and what's your intention?

> Please explain **IN DETAIL** what the changes are in this PR and why they are needed. :D

This PR follows the idea in #970 

Changes:

- Segment the `Source::Populated` property by `Age`.
- Support skip disk cache insertions for young-aged populated entries.
- Support marking region as probation (old-aged) for eviction picker `FifoPicker`.

## Checklist

- [x] I have written the necessary rustdoc comments
- [x] I have added the necessary unit tests and integration tests
- [x] I have passed `make all` (or `make fast` instead if the old tests are not modified) in my local environment.

## Related issues or PRs (optional)
close #970 