### PR TITLE
fix: fix return wrong entry on hash collision

### DIFF
--- a/foyer-storage/src/store.rs
+++ b/foyer-storage/src/store.rs
@@ -256,7 +256,8 @@ where
                 value: v,
                 populated: p,
             }),
-            Ok(l) => Ok(l),
+            Ok(Load::Entry { .. }) | Ok(Load::Miss) => Ok(Load::Miss),
+            Ok(Load::Throttled) => Ok(Load::Throttled),
             Err(e) => Err(e),
         }
     }

--- a/foyer-storage/src/store.rs
+++ b/foyer-storage/src/store.rs
@@ -1167,9 +1167,6 @@ mod tests {
             .with_hash_builder(ModRandomState::default())
             .build();
 
-        // let k1 = 1u128;
-        // let k2 = 1u128 + 1 + u64::MAX as u128;
-
         let e1 = memory.insert(1, "foo".to_string());
         let e2 = memory.insert(1 + 1 + u64::MAX as u128, "bar".to_string());
 


### PR DESCRIPTION
## What's changed and what's your intention?

> Please explain **IN DETAIL** what the changes are in this PR and why they are needed. :D

As title. Add unit test for it.

## Checklist

- [x] I have written the necessary rustdoc comments
- [x] I have added the necessary unit tests and integration tests
- [x] I have passed `make all` (or `make fast` instead if the old tests are not modified) in my local environment.

## Related issues or PRs (optional)
https://github.com/risingwavelabs/risingwave/pull/21844