### PR TITLE
test: pass clippy test on latest stable toolchain (#1008) (#1014)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,22 @@ date: 2023-05-12T11:02:09+08:00
 
 <!-- truncate -->
 
+## 2025-06-27
+
+### Releases
+
+| crate | version |
+| - | - |
+| foyer | 0.17.4 |
+| foyer-common | 0.17.4 |
+| foyer-memory | 0.17.4 |
+| foyer-storage | 0.17.4 |
+| foyer-bench | 0.17.4 |
+
+### Changes
+
+- Use `BuildHasherDefault<XxHash64>` as `DefaultHasher` to make hash results consistent across runs.
+
 ## 2025-05-22
 
 ### Releases

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,7 +11,7 @@ members = [
 ]
 
 [workspace.package]
-version = "0.17.3"
+version = "0.17.4"
 edition = "2021"
 rust-version = "1.81.0"
 repository = "https://github.com/foyer-rs/foyer"
@@ -30,11 +30,10 @@ clap = { version = "4", features = ["derive"] }
 criterion = "0.5"
 equivalent = "1"
 fastrace = "0.7"
-foyer = { version = "0.17.3", path = "foyer" }
-# foyer components
-foyer-common = { version = "0.17.3", path = "foyer-common" }
-foyer-memory = { version = "0.17.3", path = "foyer-memory" }
-foyer-storage = { version = "0.17.3", path = "foyer-storage" }
+foyer = { version = "0.17.4", path = "foyer" }
+foyer-common = { version = "0.17.4", path = "foyer-common" }
+foyer-memory = { version = "0.17.4", path = "foyer-memory" }
+foyer-storage = { version = "0.17.4", path = "foyer-storage" }
 futures-core = { version = "0.3" }
 futures-util = { version = "0.3", default-features = false, features = ["std"] }
 hashbrown = "0.15"


### PR DESCRIPTION
fix: use BuilderHasherDefault<ahash::AHahser> as default hasher (#1012)## What's changed and what's your intention?

> Please explain **IN DETAIL** what the changes are in this PR and why they are needed. :D

AS IS

## Checklist

- [x] I have written the necessary rustdoc comments
- [x] I have added the necessary unit tests and integration tests
- [x] I have passed `make all` (or `make fast` instead if the old tests are not modified) in my local environment.

## Related issues or PRs (optional)
