### PR TITLE
refactor: remove unnecessary and misleading `with_flush()` API

### DIFF
--- a/README.md
+++ b/README.md
@@ -165,7 +165,6 @@ async fn main() -> Result<()> {
                         .with_iops_counter(IopsCounter::PerIoSize(NonZeroUsize::new(128 * 1024).unwrap())),
                 ),
         )
-        .with_flush(true)
         .with_recover_mode(RecoverMode::Quiet)
         .with_admission_picker(Arc::<AdmitAllPicker>::default())
         .with_compression(foyer::Compression::Lz4)

--- a/examples/hybrid_full.rs
+++ b/examples/hybrid_full.rs
@@ -71,7 +71,6 @@ async fn main() -> Result<()> {
                         .with_iops_counter(IopsCounter::PerIoSize(NonZeroUsize::new(128 * 1024).unwrap())),
                 ),
         )
-        .with_flush(true)
         .with_recover_mode(RecoverMode::Quiet)
         .with_admission_picker(Arc::<AdmitAllPicker>::default())
         .with_compression(foyer::Compression::Lz4)

--- a/foyer-bench/src/main.rs
+++ b/foyer-bench/src/main.rs
@@ -557,7 +557,6 @@ async fn benchmark(args: Args) {
     };
 
     builder = builder
-        .with_flush(args.flush)
         .with_recover_mode(args.recover_mode)
         .with_compression(args.compression)
         .with_runtime_options(match args.runtime.as_str() {

--- a/foyer-storage/src/device/direct_file.rs
+++ b/foyer-storage/src/device/direct_file.rs
@@ -314,7 +314,7 @@ impl Dev for DirectFileDevice {
         feature = "tracing",
         fastrace::trace(name = "foyer::storage::device::direct_file::flush")
     )]
-    async fn flush(&self, _: Option<RegionId>) -> Result<()> {
+    async fn sync(&self, _: Option<RegionId>) -> Result<()> {
         let file = self.file.clone();
         asyncify_with_runtime(self.runtime.write(), move || file.sync_all().map_err(Error::from)).await
     }
@@ -462,7 +462,7 @@ mod tests {
         res.unwrap();
         assert_eq!(&buf[..], &b[..]);
 
-        device.flush(None).await.unwrap();
+        device.sync(None).await.unwrap();
 
         drop(device);
 

--- a/foyer-storage/src/device/direct_fs.rs
+++ b/foyer-storage/src/device/direct_fs.rs
@@ -266,7 +266,7 @@ impl Dev for DirectFsDevice {
         feature = "tracing",
         fastrace::trace(name = "foyer::storage::device::direct_fs::flush")
     )]
-    async fn flush(&self, region: Option<super::RegionId>) -> Result<()> {
+    async fn sync(&self, region: Option<super::RegionId>) -> Result<()> {
         let flush = |region: RegionId| {
             let file = self.file(region).clone();
             asyncify_with_runtime(self.inner.runtime.write(), move || file.sync_all().map_err(Error::from))
@@ -423,7 +423,7 @@ mod tests {
         res.unwrap();
         assert_eq!(&buf[..], &b[..]);
 
-        device.flush(None).await.unwrap();
+        device.sync(None).await.unwrap();
 
         drop(device);
 

--- a/foyer-storage/src/device/mod.rs
+++ b/foyer-storage/src/device/mod.rs
@@ -209,7 +209,7 @@ pub trait Dev: Send + Sync + 'static + Sized + Clone + Debug {
 
     /// Flush the device, make sure all modifications are persisted safely on the device.
     #[must_use]
-    fn flush(&self, region: Option<RegionId>) -> impl Future<Output = Result<()>> + Send;
+    fn sync(&self, region: Option<RegionId>) -> impl Future<Output = Result<()>> + Send;
 }
 
 /// Device extend interfaces.
@@ -325,12 +325,12 @@ impl Dev for Device {
         }
     }
 
-    async fn flush(&self, region: Option<RegionId>) -> Result<()> {
+    async fn sync(&self, region: Option<RegionId>) -> Result<()> {
         match self {
-            Device::DirectFile(dev) => dev.flush(region).await,
-            Device::DirectFs(dev) => dev.flush(region).await,
+            Device::DirectFile(dev) => dev.sync(region).await,
+            Device::DirectFs(dev) => dev.sync(region).await,
             #[cfg(test)]
-            Device::Noop(dev) => dev.flush(region).await,
+            Device::Noop(dev) => dev.sync(region).await,
         }
     }
 }

--- a/foyer-storage/src/device/monitor.rs
+++ b/foyer-storage/src/device/monitor.rs
@@ -119,10 +119,10 @@ where
         feature = "tracing",
         fastrace::trace(name = "foyer::storage::device::monitor::flush")
     )]
-    async fn flush(&self, region: Option<RegionId>) -> Result<()> {
+    async fn sync(&self, region: Option<RegionId>) -> Result<()> {
         let now = Instant::now();
 
-        let res = self.device.flush(region).await;
+        let res = self.device.sync(region).await;
 
         self.stats.record_disk_flush();
 
@@ -171,8 +171,8 @@ where
         self.read(buf, region, offset).await
     }
 
-    async fn flush(&self, region: Option<RegionId>) -> Result<()> {
-        self.flush(region).await
+    async fn sync(&self, region: Option<RegionId>) -> Result<()> {
+        self.sync(region).await
     }
 }
 

--- a/foyer-storage/src/device/test_utils.rs
+++ b/foyer-storage/src/device/test_utils.rs
@@ -57,7 +57,7 @@ impl Dev for NoopDevice {
         (buf, Ok(()))
     }
 
-    async fn flush(&self, _: Option<super::RegionId>) -> Result<()> {
+    async fn sync(&self, _: Option<super::RegionId>) -> Result<()> {
         Ok(())
     }
 }

--- a/foyer-storage/src/large/flusher.rs
+++ b/foyer-storage/src/large/flusher.rs
@@ -197,7 +197,6 @@ where
             indexer,
             tombstone_log,
             compression: config.compression,
-            flush: config.flush,
             runtime: runtime.clone(),
             metrics: metrics.clone(),
             io_tasks: VecDeque::with_capacity(1),
@@ -293,7 +292,6 @@ where
     tombstone_log: Option<TombstoneLog>,
 
     compression: Compression,
-    flush: bool,
 
     _device: MonitoredDevice,
 
@@ -463,7 +461,6 @@ where
             .map(|(i, (Region { blob_parts }, region_handle))| {
                 let indexer = self.indexer.clone();
                 let region_manager = self.region_manager.clone();
-                let flush = self.flush;
                 let metrics = self.metrics.clone();
 
                 async move {
@@ -524,10 +521,6 @@ where
                                         );
                                     }
                                     res?;
-
-                                    if flush {
-                                        region.flush().await?;
-                                    }
                                 } else {
                                     tracing::trace!(
                                         id,

--- a/foyer-storage/src/large/generic.rs
+++ b/foyer-storage/src/large/generic.rs
@@ -71,7 +71,6 @@ where
     pub device: MonitoredDevice,
     pub regions: Range<RegionId>,
     pub compression: Compression,
-    pub flush: bool,
     pub indexer_shards: usize,
     pub recover_mode: RecoverMode,
     pub recover_concurrency: usize,
@@ -97,7 +96,6 @@ where
         f.debug_struct("GenericStoreConfig")
             .field("device", &self.device)
             .field("compression", &self.compression)
-            .field("flush", &self.flush)
             .field("indexer_shards", &self.indexer_shards)
             .field("recover_mode", &self.recover_mode)
             .field("recover_concurrency", &self.recover_concurrency)
@@ -150,8 +148,6 @@ where
 
     submit_queue_size: Arc<AtomicUsize>,
     submit_queue_size_threshold: usize,
-
-    flush: bool,
 
     sequence: AtomicSequence,
 
@@ -290,7 +286,6 @@ where
                 reclaimers,
                 submit_queue_size,
                 submit_queue_size_threshold: config.submit_queue_size_threshold,
-                flush: config.flush,
                 sequence,
                 runtime: config.runtime,
                 active: AtomicBool::new(true),
@@ -537,7 +532,7 @@ where
         try_join_all((0..self.inner.region_manager.regions() as RegionId).map(|id| {
             let region = self.inner.region_manager.region(id).clone();
             async move {
-                let res = RegionCleaner::clean(&region, self.inner.flush).await;
+                let res = RegionCleaner::clean(&region).await;
                 region.statistics().reset();
                 res
             }
@@ -671,7 +666,6 @@ mod tests {
             device,
             regions,
             compression: Compression::None,
-            flush: true,
             indexer_shards: 4,
             recover_mode: RecoverMode::Strict,
             recover_concurrency: 2,
@@ -700,7 +694,6 @@ mod tests {
             device,
             regions,
             compression: Compression::None,
-            flush: true,
             indexer_shards: 4,
             recover_mode: RecoverMode::Strict,
             recover_concurrency: 2,

--- a/foyer-storage/src/large/tombstone.rs
+++ b/foyer-storage/src/large/tombstone.rs
@@ -299,7 +299,7 @@ where
         self.buffer = Some(buf);
         res?;
         if self.sync {
-            self.device.flush(Some(self.region)).await?;
+            self.device.sync(Some(self.region)).await?;
         }
         Ok(())
     }

--- a/foyer-storage/src/region.rs
+++ b/foyer-storage/src/region.rs
@@ -106,8 +106,9 @@ impl Region {
         self.inner.device.read(buf, self.id, offset).await
     }
 
-    pub(crate) async fn flush(&self) -> Result<()> {
-        self.inner.device.flush(Some(self.id)).await
+    #[expect(unused)]
+    pub(crate) async fn sync(&self) -> Result<()> {
+        self.inner.device.sync(Some(self.id)).await
     }
 }
 

--- a/foyer-storage/src/small/generic.rs
+++ b/foyer-storage/src/small/generic.rs
@@ -53,7 +53,6 @@ where
     pub set_cache_shards: usize,
     pub device: MonitoredDevice,
     pub regions: Range<RegionId>,
-    pub flush: bool,
     pub flushers: usize,
     pub buffer_pool_size: usize,
     pub runtime: Runtime,
@@ -72,7 +71,6 @@ where
             .field("set_cache_shards", &self.set_cache_shards)
             .field("device", &self.device)
             .field("regions", &self.regions)
-            .field("flush", &self.flush)
             .field("flushers", &self.flushers)
             .field("buffer_pool_size", &self.buffer_pool_size)
             .field("runtime", &self.runtime)
@@ -348,7 +346,6 @@ mod tests {
             set_cache_shards: 1,
             device,
             regions,
-            flush: false,
             flushers: 1,
             buffer_pool_size: ByteSize::kib(64).as_u64() as _,
             runtime: Runtime::new(None, None, Handle::current()),

--- a/foyer-storage/src/small/set_manager.rs
+++ b/foyer-storage/src/small/set_manager.rs
@@ -69,7 +69,6 @@ struct SetManagerInner {
     set_size: usize,
     device: MonitoredDevice,
     regions: Range<RegionId>,
-    flush: bool,
 
     metrics: Arc<Metrics>,
 }
@@ -90,7 +89,6 @@ impl Debug for SetManager {
             .field("set_size", &self.inner.set_size)
             .field("device", &self.inner.device)
             .field("regions", &self.inner.regions)
-            .field("flush", &self.inner.flush)
             .field("metrics", &self.inner.metrics)
             .finish()
     }
@@ -129,7 +127,6 @@ impl SetManager {
             set_size: config.set_size,
             device,
             regions,
-            flush: config.flush,
             metrics: config.device.metrics().clone(),
         };
         let inner = Arc::new(inner);
@@ -193,9 +190,6 @@ impl SetManager {
         let (region, offset) = self.locate(sid);
         let (_, res) = self.inner.device.write(buffer, region, offset).await;
         res?;
-        if self.inner.flush {
-            self.inner.device.flush(Some(region)).await?;
-        }
 
         // Release set lock.
         drop(set);

--- a/foyer-storage/src/store.rs
+++ b/foyer-storage/src/store.rs
@@ -444,7 +444,6 @@ where
     admission_picker: Arc<dyn AdmissionPicker>,
     compression: Compression,
     recover_mode: RecoverMode,
-    flush: bool,
 }
 
 impl<K, V, S, P> Debug for StoreBuilder<K, V, S, P>
@@ -465,7 +464,6 @@ where
             .field("admission_picker", &self.admission_picker)
             .field("compression", &self.compression)
             .field("recover_mode", &self.recover_mode)
-            .field("flush", &self.flush)
             .finish()
     }
 }
@@ -500,21 +498,12 @@ where
             admission_picker: Arc::<AdmitAllPicker>::default(),
             compression: Compression::default(),
             recover_mode: RecoverMode::default(),
-            flush: false,
         }
     }
 
     /// Set device options for the disk cache store.
     pub fn with_device_options(mut self, device_options: impl Into<DeviceOptions>) -> Self {
         self.device_options = device_options.into();
-        self
-    }
-
-    /// Enable/disable `sync` after writes.
-    ///
-    /// Default: `false`.
-    pub fn with_flush(mut self, flush: bool) -> Self {
-        self.flush = flush;
         self
     }
 
@@ -627,7 +616,6 @@ where
                                     device,
                                     regions,
                                     compression: self.compression,
-                                    flush: self.flush,
                                     indexer_shards: large.indexer_shards,
                                     recover_mode: self.recover_mode,
                                     recover_concurrency: large.recover_concurrency,
@@ -653,7 +641,6 @@ where
                                     set_cache_shards: small.set_cache_shards,
                                     device,
                                     regions,
-                                    flush: self.flush,
                                     flushers: small.flushers,
                                     buffer_pool_size: small.buffer_pool_size,
                                     runtime,
@@ -673,7 +660,6 @@ where
                                         set_cache_shards: small.set_cache_shards,
                                         device: device.clone(),
                                         regions: small_regions,
-                                        flush: self.flush,
                                         flushers: small.flushers,
                                         buffer_pool_size: small.buffer_pool_size,
                                         runtime: runtime.clone(),
@@ -683,7 +669,6 @@ where
                                         device,
                                         regions: large_regions,
                                         compression: self.compression,
-                                        flush: self.flush,
                                         indexer_shards: large.indexer_shards,
                                         recover_mode: self.recover_mode,
                                         recover_concurrency: large.recover_concurrency,

--- a/foyer-storage/tests/storage_fuzzy_test.rs
+++ b/foyer-storage/tests/storage_fuzzy_test.rs
@@ -124,7 +124,6 @@ fn basic(
             .with_file_size(MB),
     )
     .with_admission_picker(recorder.clone())
-    .with_flush(true)
 }
 
 #[test_log::test(tokio::test)]

--- a/foyer/src/hybrid/builder.rs
+++ b/foyer/src/hybrid/builder.rs
@@ -245,20 +245,6 @@ where
         }
     }
 
-    /// Enable/disable `sync` after writes.
-    ///
-    /// Default: `false`.
-    pub fn with_flush(self, flush: bool) -> Self {
-        let builder = self.builder.with_flush(flush);
-        Self {
-            name: self.name,
-            options: self.options,
-            metrics: self.metrics,
-            memory: self.memory,
-            builder,
-        }
-    }
-
     /// Set the recover mode for the disk cache store.
     ///
     /// See more in [`RecoverMode`].


### PR DESCRIPTION
## What's changed and what's your intention?

> Please explain **IN DETAIL** what the changes are in this PR and why they are needed. :D

AS IS

## Checklist

- [x] I have written the necessary rustdoc comments
- [x] I have added the necessary unit tests and integration tests
- [x] I have passed `cargo x` (or `cargo x --fast` instead if the old tests are not modified) in my local environment.

## Related issues or PRs (optional)
close #1039 