### PR TITLE
refactor: load no more spawn a task in read runtime.

### DIFF
--- a/foyer-storage/src/store.rs
+++ b/foyer-storage/src/store.rs
@@ -204,7 +204,7 @@ where
         }
 
         let future = self.inner.engine.load(hash);
-        match self.inner.runtime.read().spawn(future).await.unwrap() {
+        match future.await {
             Ok(Load::Entry {
                 key: k,
                 value: v,


### PR DESCRIPTION
Since some engine doesn't rely on it.

## What's changed and what's your intention?

> Please explain **IN DETAIL** what the changes are in this PR and why they are needed. :D

There is no need to spawn a task since IO engine already handles it.

Need to run e2e benchmark with RW to see if this refactoring increases the latency.

## Checklist

- [x] I have written the necessary rustdoc comments
- [x] I have added the necessary unit tests and integration tests
- [x] I have passed `cargo x` (or `cargo x --fast` instead if the old tests are not modified) in my local environment.

## Related issues or PRs (optional)
