### PR TITLE
Adds AntTP to 'Projects Using Foyer' section of README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,7 +60,7 @@ Feel free to open a PR and add your projects here:
 - [Percas](https://github.com/scopedb/percas): A distributed persistent cache service optimized for high performance NVMe SSD.
 - [dna](https://github.com/apibara/dna): The fastest platform to build production-grade indexers that connect onchain data to web2 services.
 - [si](https://github.com/systeminit/si): The System Initiative software.
-- [AntTP](https://github.com/traktion/AntTP): AntTP is a HTTP service which serves data from Autonomi over conventional HTTP connections.
+- [AntTP](https://github.com/traktion/AntTP): Serves Autonomi Network data over HTTP protocol.
 
 ## Quick Start
 

--- a/README.md
+++ b/README.md
@@ -60,6 +60,7 @@ Feel free to open a PR and add your projects here:
 - [Percas](https://github.com/scopedb/percas): A distributed persistent cache service optimized for high performance NVMe SSD.
 - [dna](https://github.com/apibara/dna): The fastest platform to build production-grade indexers that connect onchain data to web2 services.
 - [si](https://github.com/systeminit/si): The System Initiative software.
+- [AntTP](https://github.com/traktion/AntTP): AntTP is a HTTP service which serves data from Autonomi over conventional HTTP connections.
 
 ## Quick Start
 


### PR DESCRIPTION
## What's changed and what's your intention?

Adds AntTP to 'Projects Using Foyer' section of README.md. Loving this library!

## Checklist

- [X] I have written the necessary rustdoc comments
- [X] I have added the necessary unit tests and integration tests
- [X] I have passed `cargo x` (or `cargo x --fast` instead if the old tests are not modified) in my local environment.

## Related issues or PRs (optional)
