### PR TITLE
feat: support insert disposable entry to make api competiable in future

### DIFF
--- a/foyer-common/src/properties.rs
+++ b/foyer-common/src/properties.rs
@@ -104,7 +104,8 @@ impl Default for Source {
 pub trait Properties: Send + Sync + 'static + Clone + Default + Debug {
     /// Set disposable.
     ///
-    /// If an entry is disposable, it will not actually inserted into the cache and removed immediately after the last reference drops.
+    /// If an entry is disposable, it will not actually inserted into the cache and removed immediately after the last
+    /// reference drops.
     ///
     /// Disposable property is used to simplify the design consistency of the APIs.
     fn with_disposable(self, disposable: bool) -> Self;

--- a/foyer-common/src/properties.rs
+++ b/foyer-common/src/properties.rs
@@ -102,7 +102,21 @@ impl Default for Source {
 /// The in-memory only cache and the hybrid cache may have different properties implementations to minimize the overhead
 /// of necessary properties in different scenarios.
 pub trait Properties: Send + Sync + 'static + Clone + Default + Debug {
+    /// Set disposable.
+    ///
+    /// If an entry is disposable, it will not actually inserted into the cache and removed immediately after the last reference drops.
+    ///
+    /// Disposable property is used to simplify the design consistency of the APIs.
+    fn with_disposable(self, disposable: bool) -> Self;
+
+    /// Entry disposable.
+    fn disposable(&self) -> Option<bool>;
+
     /// Set entry ephemeral.
+    ///
+    /// Ephemeral entries are removed immediately after the last reference drops.
+    ///
+    /// Ephemeral property is used by disk-cache-only cache entries.
     fn with_ephemeral(self, ephemeral: bool) -> Self;
 
     /// Entry ephemeral.

--- a/foyer-memory/src/cache.rs
+++ b/foyer-memory/src/cache.rs
@@ -43,18 +43,33 @@ use crate::{
 /// Entry properties for in-memory only cache.
 #[derive(Debug, Clone, Default)]
 pub struct CacheProperties {
+    disposable: bool,
     ephemeral: bool,
     hint: Hint,
 }
 
 impl CacheProperties {
+    /// Set disposable.
+    ///
+    /// If an entry is disposable, it will not actually inserted into the cache and removed immediately after the last reference drops.
+    ///
+    /// Disposable property is used to simplify the design consistency of the APIs.
+    fn with_disposable(mut self, disposable: bool) -> Self {
+        self.disposable = disposable;
+        self
+    }
+
+    /// Get if the entry is disposable.
+    fn disposable(&self) -> bool {
+        self.disposable
+    }
+
     /// Set the entry to be ephemeral.
     ///
     /// An ephemeral entry will be evicted immediately after all its holders drop it,
     /// no matter if the capacity is reached.
-    pub fn with_ephemeral(mut self, ephemeral: bool) -> Self {
-        self.ephemeral = ephemeral;
-        self
+    pub fn with_ephemeral(self, ephemeral: bool) -> Self {
+        Self { ephemeral, ..self }
     }
 
     /// Get if the entry is ephemeral.
@@ -75,6 +90,14 @@ impl CacheProperties {
 }
 
 impl Properties for CacheProperties {
+    fn with_disposable(self, disposable: bool) -> Self {
+        self.with_disposable(disposable)
+    }
+
+    fn disposable(&self) -> Option<bool> {
+        Some(self.disposable())
+    }
+
     fn with_ephemeral(self, ephemeral: bool) -> Self {
         self.with_ephemeral(ephemeral)
     }

--- a/foyer-memory/src/cache.rs
+++ b/foyer-memory/src/cache.rs
@@ -51,7 +51,8 @@ pub struct CacheProperties {
 impl CacheProperties {
     /// Set disposable.
     ///
-    /// If an entry is disposable, it will not actually inserted into the cache and removed immediately after the last reference drops.
+    /// If an entry is disposable, it will not actually inserted into the cache and removed immediately after the last
+    /// reference drops.
     ///
     /// Disposable property is used to simplify the design consistency of the APIs.
     fn with_disposable(mut self, disposable: bool) -> Self {

--- a/foyer-memory/src/eviction/test_utils.rs
+++ b/foyer-memory/src/eviction/test_utils.rs
@@ -81,6 +81,7 @@ pub fn assert_ptr_vec_vec_eq<T>(vva: Vec<Vec<Arc<T>>>, vvb: Vec<Vec<Arc<T>>>) {
 /// Properties for test, support all properties.
 #[derive(Debug, Clone, Default)]
 pub struct TestProperties {
+    disposable: bool,
     ephemeral: bool,
     hint: Hint,
     location: Location,
@@ -88,6 +89,15 @@ pub struct TestProperties {
 }
 
 impl Properties for TestProperties {
+    fn with_disposable(mut self, disposable: bool) -> Self {
+        self.disposable = disposable;
+        self
+    }
+
+    fn disposable(&self) -> Option<bool> {
+        Some(self.disposable)
+    }
+
     fn with_ephemeral(mut self, ephemeral: bool) -> Self {
         self.ephemeral = ephemeral;
         self

--- a/foyer-memory/src/raw.rs
+++ b/foyer-memory/src/raw.rs
@@ -581,6 +581,16 @@ where
 
     #[cfg_attr(feature = "tracing", fastrace::trace(name = "foyer::memory::raw::insert_inner"))]
     fn insert_inner(&self, record: Arc<Record<E>>) -> RawCacheEntry<E, S, I> {
+        if record.properties().disposable().unwrap_or_default() {
+            // If the record is disposable, we do not insert it into the cache.
+            // Instead, we just return it and let it be dropped immediately after the last reference drops.
+            record.inc_refs(1);
+            return RawCacheEntry {
+                record,
+                inner: self.inner.clone(),
+            };
+        }
+
         let mut garbages = vec![];
         let mut waiters = vec![];
 
@@ -808,6 +818,11 @@ where
         let shard = &self.inner.shards[hash as usize % self.inner.shards.len()];
 
         if self.record.dec_refs(1) == 0 {
+            if !self.record.properties().disposable().unwrap_or_default() {
+                // TODO(MrCroxx): Send it to disk cache write queue with pipe?
+                return;
+            }
+
             match E::release() {
                 Op::Noop => {}
                 Op::Immutable(_) => shard.read().with(|shard| shard.release_immutable(&self.record)),
@@ -1274,6 +1289,23 @@ mod tests {
         assert_eq!(fifo.usage(), 1);
         drop(e2b);
         assert_eq!(fifo.usage(), 1);
+    }
+
+    #[test_log::test]
+    fn test_insert_disposable() {
+        let fifo = fifo_cache_for_test();
+
+        let e1 = fifo.insert_with_properties(1, 1, TestProperties::default().with_disposable(true));
+        assert_eq!(fifo.usage(), 0);
+        drop(e1);
+        assert_eq!(fifo.usage(), 0);
+
+        let e2a = fifo.insert_with_properties(2, 2, TestProperties::default().with_disposable(true));
+        assert_eq!(fifo.usage(), 0);
+        assert!(fifo.get(&2).is_none());
+        assert_eq!(fifo.usage(), 0);
+        drop(e2a);
+        assert_eq!(fifo.usage(), 0);
     }
 
     #[test]

--- a/foyer-memory/src/raw.rs
+++ b/foyer-memory/src/raw.rs
@@ -818,7 +818,7 @@ where
         let shard = &self.inner.shards[hash as usize % self.inner.shards.len()];
 
         if self.record.dec_refs(1) == 0 {
-            if !self.record.properties().disposable().unwrap_or_default() {
+            if self.record.properties().disposable().unwrap_or_default() {
                 // TODO(MrCroxx): Send it to disk cache write queue with pipe?
                 return;
             }

--- a/foyer/src/hybrid/cache.rs
+++ b/foyer/src/hybrid/cache.rs
@@ -93,6 +93,7 @@ macro_rules! try_cancel {
 /// Entry properties for in-memory only cache.
 #[derive(Debug, Clone, Default)]
 pub struct HybridCacheProperties {
+    disposable: bool,
     ephemeral: bool,
     hint: Hint,
     location: Location,
@@ -100,6 +101,21 @@ pub struct HybridCacheProperties {
 }
 
 impl HybridCacheProperties {
+    /// Set disposable.
+    ///
+    /// If an entry is disposable, it will not actually inserted into the cache and removed immediately after the last reference drops.
+    ///
+    /// Disposable property is used to simplify the design consistency of the APIs.
+    fn with_disposable(mut self, disposable: bool) -> Self {
+        self.disposable = disposable;
+        self
+    }
+
+    /// Get if the entry is disposable.
+    fn disposable(&self) -> bool {
+        self.disposable
+    }
+
     /// Set the entry to be ephemeral.
     ///
     /// An ephemeral entry will be evicted immediately after all its holders drop it,
@@ -143,6 +159,14 @@ impl HybridCacheProperties {
 }
 
 impl Properties for HybridCacheProperties {
+    fn with_disposable(self, disposable: bool) -> Self {
+        self.with_disposable(disposable)
+    }
+
+    fn disposable(&self) -> Option<bool> {
+        Some(self.disposable())
+    }
+
     fn with_ephemeral(self, ephemeral: bool) -> Self {
         self.with_ephemeral(ephemeral)
     }

--- a/foyer/src/hybrid/cache.rs
+++ b/foyer/src/hybrid/cache.rs
@@ -103,7 +103,8 @@ pub struct HybridCacheProperties {
 impl HybridCacheProperties {
     /// Set disposable.
     ///
-    /// If an entry is disposable, it will not actually inserted into the cache and removed immediately after the last reference drops.
+    /// If an entry is disposable, it will not actually inserted into the cache and removed immediately after the last
+    /// reference drops.
     ///
     /// Disposable property is used to simplify the design consistency of the APIs.
     fn with_disposable(mut self, disposable: bool) -> Self {


### PR DESCRIPTION
## What's changed and what's your intention?

> Please explain **IN DETAIL** what the changes are in this PR and why they are needed. :D

In certain scenarios, users may insert oversized entries. The foyer may provide filters to help users filter these entries. However, for the consistency of the API, the insertion still needs to return a cache entry, but it does not need to actually insert it into memory; instead, it should drop it and release it immediately.

## Checklist

- [x] I have written the necessary rustdoc comments
- [x] I have added the necessary unit tests and integration tests
- [x] I have passed `cargo x` (or `cargo x --fast` instead if the old tests are not modified) in my local environment.

## Related issues or PRs (optional)
#1089 