### PR TITLE
fix: prioritize checksum comparison on deserialize

### DIFF
--- a/foyer-storage/src/engine/block/engine.rs
+++ b/foyer-storage/src/engine/block/engine.rs
@@ -1321,12 +1321,12 @@ mod tests {
             #[cfg(target_family = "unix")]
             {
                 use std::os::unix::fs::FileExt;
-                file.write_all_at(&[b'x'; 4 * 1024], 4 * 1024).unwrap();
+                file.write_all_at(&[b'x'; 42], 5 * 1024).unwrap();
             }
             #[cfg(target_family = "windows")]
             {
                 use std::os::windows::fs::FileExt;
-                file.seek_write(&[b'x'; 4 * 1024], 4 * 1024).unwrap();
+                file.seek_write(&[b'x'; 42], 5 * 1024).unwrap();
             }
         }
 

--- a/foyer-storage/src/serde.rs
+++ b/foyer-storage/src/serde.rs
@@ -177,14 +177,6 @@ impl EntryDeserializer {
             });
         }
 
-        // deserialize value
-        let buf = &buffer[..value_len];
-        let value = Self::deserialize_value(buf, compression)?;
-
-        // deserialize key
-        let buf = &buffer[value_len..value_len + ken_len];
-        let key = Self::deserialize_key(buf)?;
-
         // calculate checksum if needed
         if let Some(expected) = checksum {
             let get = Checksummer::checksum64(&buffer[..value_len + ken_len]);
@@ -192,6 +184,14 @@ impl EntryDeserializer {
                 return Err(Error::ChecksumMismatch { expected, get });
             }
         }
+
+        // deserialize value
+        let buf = &buffer[..value_len];
+        let value = Self::deserialize_value(buf, compression)?;
+
+        // deserialize key
+        let buf = &buffer[value_len..value_len + ken_len];
+        let key = Self::deserialize_key(buf)?;
 
         Ok((key, value))
     }


### PR DESCRIPTION
## What's changed and what's your intention?

> Please explain **IN DETAIL** what the changes are in this PR and why they are needed. :D

To fix panices on entry deserialization.

## Checklist

- [x] I have written the necessary rustdoc comments
- [x] I have added the necessary unit tests and integration tests
- [x] I have passed `cargo x` (or `cargo x --fast` instead if the old tests are not modified) in my local environment.

## Related issues or PRs (optional)
#1097 #1095 
~Merge after #1097~ Release version 0.19 takes priority.