### PR TITLE
fix: remove fastrace/enable when tracing is enabled

### DIFF
--- a/foyer-bench/Cargo.toml
+++ b/foyer-bench/Cargo.toml
@@ -18,7 +18,7 @@ tokio-console = ["dep:console-subscriber"]
 strict_assertions = ["foyer/strict_assertions"]
 jemalloc = ["dep:tikv-jemallocator"]
 jeprof = ["jemalloc", "tikv-jemallocator?/profiling"]
-tracing = ["foyer/tracing", "dep:fastrace-jaeger", "dep:fastrace"]
+tracing = ["fastrace/enable", "foyer/tracing", "dep:fastrace-jaeger"]
 
 [dependencies]
 anyhow = { workspace = true }

--- a/foyer-common/Cargo.toml
+++ b/foyer-common/Cargo.toml
@@ -18,7 +18,7 @@ development = ["criterion", "serde_bytes"]
 [features]
 serde = ["dep:serde", "dep:bincode"]
 strict_assertions = []
-tracing = ["fastrace/enable"]
+tracing = ["dep:fastrace"]
 
 [dependencies]
 bincode = { workspace = true, optional = true }

--- a/foyer-memory/Cargo.toml
+++ b/foyer-memory/Cargo.toml
@@ -16,7 +16,7 @@ nightly = ["hashbrown/nightly"]
 test_utils = []
 deadlock = ["parking_lot/deadlock_detection"]
 strict_assertions = ["foyer-common/strict_assertions"]
-tracing = ["fastrace/enable", "foyer-common/tracing"]
+tracing = ["dep:fastrace", "foyer-common/tracing"]
 
 [dependencies]
 arc-swap = { workspace = true }

--- a/foyer-storage/Cargo.toml
+++ b/foyer-storage/Cargo.toml
@@ -15,7 +15,7 @@ readme = { workspace = true }
 default = []
 serde = ["dep:serde"]
 clap = ["dep:clap"]
-tracing = ["fastrace/enable", "foyer-common/tracing", "foyer-memory/tracing"]
+tracing = ["dep:fastrace", "foyer-common/tracing", "foyer-memory/tracing"]
 nightly = ["allocator-api2/nightly"]
 test_utils = []
 deadlock = ["parking_lot/deadlock_detection"]

--- a/foyer/Cargo.toml
+++ b/foyer/Cargo.toml
@@ -20,7 +20,7 @@ default = []
 serde = ["foyer-common/serde", "foyer-storage/serde"]
 clap = ["foyer-storage/clap"]
 tracing = [
-  "fastrace/enable",
+  "dep:fastrace",
   "foyer-common/tracing",
   "foyer-memory/tracing",
   "foyer-storage/tracing",


### PR DESCRIPTION
## What's changed and what's your intention?

> Please explain **IN DETAIL** what the changes are in this PR and why they are needed. :D

As @andylokandy adviced, feature `fastrace/enable` is supposed to be enabled on the user's side, not the lib's side.

## Checklist

- [x] I have written the necessary rustdoc comments
- [x] I have added the necessary unit tests and integration tests
- [x] I have passed `cargo x` (or `cargo x --fast` instead if the old tests are not modified) in my local environment.

## Related issues or PRs (optional)
