### PR TITLE
fix: `is_noop()` logic so that disk cache is correctly utilized

### DIFF
--- a/foyer-storage/src/store.rs
+++ b/foyer-storage/src/store.rs
@@ -452,7 +452,7 @@ where
 
     #[doc(hidden)]
     pub fn is_noop(&self) -> bool {
-        self.io_engine.is_none()
+        self.engine_builder.is_none()
     }
 
     /// Build the disk cache store with the given configuration.


### PR DESCRIPTION
IO engine gets defaulted, but engine config determines whether the disk cache is noop

## What's changed and what's your intention?

> Please explain **IN DETAIL** what the changes are in this PR and why they are needed. :D

I was seeing no disk writes happening even as entries were evicted from memory cache, because I had not explicitly provided an IO engine but was relying on the default. I did have an engine config specified.

I tracked it down to the piping logic with the default `HybridCachePolicy::WriteOnEviction`: https://github.com/foyer-rs/foyer/blob/41d4e684bc955fcc6d0a0fbd545e233e8bf22c18/foyer/src/hybrid/builder.rs#L328

## Checklist

- [x] I have written the necessary rustdoc comments
- [ ] I have added the necessary unit tests and integration tests
- [ ] I have passed `cargo x` (or `cargo x --fast` instead if the old tests are not modified) in my local environment.

## Related issues or PRs (optional)
