### PR TITLE
fix: fix issue 1121 panics on concurrent disk cache write & fetch

### DIFF
--- a/foyer-common/src/properties.rs
+++ b/foyer-common/src/properties.rs
@@ -47,24 +47,19 @@ impl Default for Hint {
 ///
 /// NOTE: `CacheLocation` only affects the first time the entry is handle.
 /// After it is populated, the entry may not follow the given advice.
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub enum Location {
     /// The default location.
     ///
     /// Prefer to store the entry in the in-memory cache with in-memory cache.
     /// And prefer to store the entry in the hybrid cache with hybrid cache.
+    #[default]
     Default,
     /// Prefer to store the entry in the in-memory cache.
     InMem,
     /// Prefer to store the entry on the disk cache.
     OnDisk,
-}
-
-impl Default for Location {
-    fn default() -> Self {
-        Self::Default
-    }
 }
 
 /// Entry age in the disk cache. Used by hybrid cache.
@@ -106,16 +101,16 @@ impl Default for Source {
 /// The in-memory only cache and the hybrid cache may have different properties implementations to minimize the overhead
 /// of necessary properties in different scenarios.
 pub trait Properties: Send + Sync + 'static + Clone + Default + Debug {
-    /// Set disposable.
+    /// Set entry as a phantom entry.
     ///
-    /// If an entry is disposable, it will not actually inserted into the cache and removed immediately after the last
-    /// reference drops.
+    /// A phantom entry will not be actually inserted into the in-memory cache.
+    /// It is only used to keep the APIs consistent.
     ///
-    /// Disposable property is used to simplify the design consistency of the APIs.
-    fn with_disposable(self, disposable: bool) -> Self;
+    /// NOTE: This API is for internal usage only. It MUST NOT be exported publicly.
+    fn with_phantom(self, phantom: bool) -> Self;
 
-    /// Entry disposable.
-    fn disposable(&self) -> Option<bool>;
+    /// If the entry is a phantom entry.
+    fn phantom(&self) -> Option<bool>;
 
     /// Set entry hint.
     fn with_hint(self, hint: Hint) -> Self;

--- a/foyer-memory/src/cache.rs
+++ b/foyer-memory/src/cache.rs
@@ -43,26 +43,19 @@ use crate::{
 /// Entry properties for in-memory only cache.
 #[derive(Debug, Clone, Default)]
 pub struct CacheProperties {
-    disposable: bool,
-
+    phantom: bool,
     hint: Hint,
 }
 
 impl CacheProperties {
     /// Set disposable.
-    ///
-    /// If an entry is disposable, it will not actually inserted into the cache and removed immediately after the last
-    /// reference drops.
-    ///
-    /// Disposable property is used to simplify the design consistency of the APIs.
-    pub fn with_disposable(mut self, disposable: bool) -> Self {
-        self.disposable = disposable;
+    fn with_phantom(mut self, phantom: bool) -> Self {
+        self.phantom = phantom;
         self
     }
 
-    /// Get if the entry is disposable.
-    pub fn disposable(&self) -> bool {
-        self.disposable
+    fn phantom(&self) -> bool {
+        self.phantom
     }
 
     /// Set entry hint.
@@ -78,12 +71,12 @@ impl CacheProperties {
 }
 
 impl Properties for CacheProperties {
-    fn with_disposable(self, disposable: bool) -> Self {
-        self.with_disposable(disposable)
+    fn with_phantom(self, phantom: bool) -> Self {
+        self.with_phantom(phantom)
     }
 
-    fn disposable(&self) -> Option<bool> {
-        Some(self.disposable())
+    fn phantom(&self) -> Option<bool> {
+        Some(self.phantom())
     }
 
     fn with_hint(self, hint: Hint) -> Self {

--- a/foyer-memory/src/eviction/test_utils.rs
+++ b/foyer-memory/src/eviction/test_utils.rs
@@ -81,20 +81,20 @@ pub fn assert_ptr_vec_vec_eq<T>(vva: Vec<Vec<Arc<T>>>, vvb: Vec<Vec<Arc<T>>>) {
 /// Properties for test, support all properties.
 #[derive(Debug, Clone, Default)]
 pub struct TestProperties {
-    disposable: bool,
+    phantom: bool,
     hint: Hint,
     location: Location,
     source: Source,
 }
 
 impl Properties for TestProperties {
-    fn with_disposable(mut self, disposable: bool) -> Self {
-        self.disposable = disposable;
+    fn with_phantom(mut self, phantom: bool) -> Self {
+        self.phantom = phantom;
         self
     }
 
-    fn disposable(&self) -> Option<bool> {
-        Some(self.disposable)
+    fn phantom(&self) -> Option<bool> {
+        Some(self.phantom)
     }
 
     fn with_hint(mut self, hint: Hint) -> Self {

--- a/foyer/Cargo.toml
+++ b/foyer/Cargo.toml
@@ -18,15 +18,16 @@ rustdoc-args = ["--cfg", "docsrs"]
 
 [features]
 default = []
-serde = ["foyer-common/serde", "foyer-storage/serde"]
 clap = ["foyer-storage/clap"]
+serde = ["foyer-common/serde", "foyer-storage/serde"]
+nightly = ["foyer-storage/nightly", "foyer-memory/nightly"]
 tracing = [
   "dep:fastrace",
   "foyer-common/tracing",
   "foyer-memory/tracing",
   "foyer-storage/tracing",
 ]
-nightly = ["foyer-storage/nightly", "foyer-memory/nightly"]
+test_utils = ["foyer-storage/test_utils"]
 deadlock = ["foyer-storage/deadlock"]
 strict_assertions = [
   "foyer-common/strict_assertions",
@@ -69,9 +70,15 @@ tokio = { workspace = true, features = [
 ] }
 
 [dev-dependencies]
+foyer = { workspace = true, features = ["test_utils"] }
 foyer-storage = { workspace = true, features = ["test_utils"] }
+rand = "0.9"
 tempfile = { workspace = true }
 test-log = { workspace = true, features = ["trace", "color"] }
 
 [lints]
 workspace = true
+
+[[test]]
+name = "hybrid_cache_fuzzy_test"
+required-features = ["test_utils"]

--- a/foyer/src/hybrid/writer.rs
+++ b/foyer/src/hybrid/writer.rs
@@ -23,7 +23,7 @@ use foyer_common::{
 };
 use foyer_storage::StorageFilterResult;
 
-use crate::{HybridCache, HybridCacheEntry, HybridCachePolicy, HybridCacheProperties};
+use crate::{HybridCache, HybridCacheEntry, HybridCacheProperties};
 
 /// Writer for hybrid cache to support more flexible write APIs.
 pub struct HybridCacheWriter<K, V, S = DefaultHasher>
@@ -141,11 +141,7 @@ where
 
         let entry = self
             .hybrid
-            .memory()
-            .insert_with_properties(self.key, value, properties.with_disposable(true));
-        if self.hybrid.policy() == HybridCachePolicy::WriteOnInsertion {
-            self.hybrid.storage().enqueue(entry.piece(), true);
-        }
+            .insert_with_properties(self.key, value, properties.with_phantom(true));
         self.hybrid.metrics().hybrid_insert.increase(1);
         self.hybrid
             .metrics()

--- a/foyer/tests/hybrid_cache_fuzzy_test.rs
+++ b/foyer/tests/hybrid_cache_fuzzy_test.rs
@@ -1,0 +1,177 @@
+// Copyright 2025 foyer Project Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//! Fuzzy test for foyer hybrid cache.
+
+use std::{
+    collections::VecDeque,
+    sync::{
+        atomic::{AtomicU64, Ordering},
+        Arc, RwLock,
+    },
+    time::Duration,
+};
+
+use foyer::{
+    BlockEngineBuilder, DeviceBuilder, Event, EventListener, FsDeviceBuilder, HybridCache, HybridCacheBuilder,
+    HybridCachePolicy, HybridCacheProperties, IoEngineBuilder, Location, PsyncIoEngineBuilder,
+};
+use rand::{rng, Rng};
+
+const KB: usize = 1024;
+const MB: usize = 1024 * KB;
+
+const WRITERS: usize = 8;
+const READERS: usize = 16;
+
+const WRITES: usize = 1000;
+const DUPLICATES: usize = 10;
+const READS: usize = 1000;
+
+const FETCH_WAIT: Duration = Duration::from_millis(10);
+const WRITE_WAIT: Duration = Duration::from_millis(1);
+const READ_WAIT: Duration = Duration::from_millis(1);
+
+const INTERVAL: usize = 100;
+
+#[derive(Debug)]
+struct RecentEvictionQueue {
+    queue: RwLock<VecDeque<u64>>,
+    capacity: usize,
+}
+
+impl EventListener for RecentEvictionQueue {
+    type Key = u64;
+    type Value = Vec<u8>;
+
+    fn on_leave(&self, _: Event, key: &Self::Key, _: &Self::Value) {
+        let mut queue = self.queue.write().unwrap();
+        if queue.len() < self.capacity {
+            queue.push_back(*key)
+        } else {
+            queue.pop_front();
+            queue.push_back(*key);
+        }
+    }
+}
+
+impl RecentEvictionQueue {
+    fn new(capacity: usize) -> Self {
+        Self {
+            queue: RwLock::new(VecDeque::with_capacity(capacity)),
+            capacity,
+        }
+    }
+
+    fn pick(&self) -> Option<u64> {
+        let queue = self.queue.read().unwrap();
+        if queue.is_empty() {
+            return None;
+        }
+        let index = rng().random_range(0..queue.len());
+        Some(queue[index])
+    }
+}
+
+#[test_log::test(tokio::test)]
+async fn test_concurrent_insert_disk_cache_and_fetch() {
+    let dir = tempfile::tempdir().unwrap();
+
+    let recent = Arc::new(RecentEvictionQueue::new(10));
+
+    let hybrid: HybridCache<u64, Vec<u8>> = HybridCacheBuilder::new()
+        .with_name("test")
+        .with_policy(HybridCachePolicy::WriteOnEviction)
+        .with_event_listener(recent.clone())
+        .memory(MB)
+        .with_weighter(|_, v| 8 + v.len())
+        .storage()
+        .with_io_engine(PsyncIoEngineBuilder::new().build().await.unwrap())
+        .with_engine_config(
+            BlockEngineBuilder::new(FsDeviceBuilder::new(dir).with_capacity(64 * MB).build().unwrap())
+                .with_block_size(4 * MB),
+        )
+        .build()
+        .await
+        .unwrap();
+
+    let idx = Arc::new(AtomicU64::new(0));
+
+    let mut handles = vec![];
+    for _ in 0..WRITERS {
+        let h = hybrid.clone();
+        let r = recent.clone();
+        let i = idx.clone();
+        handles.push(tokio::spawn(async move { write(h, r, i).await }));
+    }
+    for _ in 0..READERS {
+        let h = hybrid.clone();
+        let r = recent.clone();
+        handles.push(tokio::spawn(async move { read(h, r).await }));
+    }
+    for h in handles {
+        h.await.unwrap();
+    }
+}
+
+fn value(key: u64) -> Vec<u8> {
+    vec![key as u8; 4 * KB]
+}
+
+async fn write(hybrid: HybridCache<u64, Vec<u8>>, _: Arc<RecentEvictionQueue>, idx: Arc<AtomicU64>) {
+    loop {
+        let key = idx.fetch_add(1, Ordering::Relaxed);
+        if key > WRITES as u64 {
+            break;
+        }
+        if key % INTERVAL as u64 == 0 {
+            tracing::info!("Inserted {key} items");
+        }
+        for k in key.saturating_sub(DUPLICATES as u64)..=key {
+            hybrid.insert_with_properties(
+                k,
+                value(k),
+                HybridCacheProperties::default().with_location(Location::OnDisk),
+            );
+            tokio::time::sleep(WRITE_WAIT).await;
+        }
+    }
+}
+
+async fn read(hybrid: HybridCache<u64, Vec<u8>>, recent: Arc<RecentEvictionQueue>) {
+    let mut cnt = 0;
+    loop {
+        tokio::time::sleep(READ_WAIT).await;
+        let key = match recent.pick() {
+            Some(v) => v,
+            None => continue,
+        };
+        let e = hybrid
+            .fetch(key, || async move {
+                tokio::time::sleep(FETCH_WAIT).await;
+                Ok(value(key))
+            })
+            .await
+            .unwrap();
+
+        assert_eq!(e.value(), &value(key));
+        cnt += 1;
+        if cnt % INTERVAL as u64 == 0 {
+            tracing::info!("Read {cnt} items");
+        }
+        if cnt >= READS as u64 {
+            break;
+        }
+    }
+}


### PR DESCRIPTION
## What's changed and what's your intention?

> Please explain **IN DETAIL** what the changes are in this PR and why they are needed. :D

#1121 Addressed the root cause of panics on concurrent disk cache writes & fetches.

#1123 Removed the buggy code path, but may lead to deadlock on the same case.

#1143 Tried to fix it, which is useless with #1123.

This PR refined handling of phantom (previsouly *disposable*) entries and fix the root cause.

Changes:

- Refine the handling of phantom entries.
- Rename `disposable` to `phantom` for better understanding.
- Introduce fuzzy test to make sure it race condition is elimiated.

## Checklist

- [x] I have written the necessary rustdoc comments
- [x] I have added the necessary unit tests and integration tests
- [x] I have passed `cargo x` (or `cargo x --fast` instead if the old tests are not modified) in my local environment.

## Related issues or PRs (optional)
Fix #1121
Close #1143
#1123