### PR TITLE
fix: removed unnecessary constraints to allow use of non-static keys

### DIFF
--- a/foyer-storage/src/store.rs
+++ b/foyer-storage/src/store.rs
@@ -161,7 +161,7 @@ where
     /// Load a cache entry from the disk cache.
     pub async fn load<Q>(&self, key: &Q) -> Result<Load<K, V, P>>
     where
-        Q: Hash + Equivalent<K> + ?Sized + Send + Sync + 'static,
+        Q: Hash + Equivalent<K> + ?Sized,
     {
         let now = Instant::now();
 

--- a/foyer/src/hybrid/cache.rs
+++ b/foyer/src/hybrid/cache.rs
@@ -578,7 +578,7 @@ where
     /// Get cached entry with the given key from the hybrid cache.
     pub async fn get<Q>(&self, key: &Q) -> Result<Option<HybridCacheEntry<K, V, S>>>
     where
-        Q: Hash + Equivalent<K> + Send + Sync + 'static + Clone,
+        Q: Hash + Equivalent<K>,
     {
         root_span!(self, span, "foyer::hybrid::cache::get");
 


### PR DESCRIPTION
## What's changed and what's your intention?

This PR removes an unnecessary constraint on the key in `Store::load`, bringing it in line with the constraints used in the other public store api functions such as `Store::delete` & `Store::may_contains`.

`Send + Sync + 'static` is entirely unnecessary here as the hash is passed to the spawned task and not the key itself.

This change allows using non-static (e.g. borrowed) keys when calling `Store::load`. In my particular case I was using a wrapper with borrowed values + `Equivalent` with the store api, but the `'static` constraint would not allow it, therefore requiring me to clone my keys on each load attempt. Thankfully, the `Send + Sync + 'static` constraint appears to be an an artifact of possibly a previous version of the function and is completely unnecessary at this point, so by simply removing it the use of borrowed keys works just fine.

## Checklist

- [X] I have written the necessary rustdoc comments
- [X] I have added the necessary unit tests and integration tests
- [x] I have passed `cargo x` (or `cargo x --fast` instead if the old tests are not modified) in my local environment.

## Related issues or PRs (optional)

Fyi, running `cargo x` or `cargo x --fast` always fails due to `cargo sort -w` not liking '.' in `Cargo.toml` key fields:

```
$ cargo x --fast
    Finished `dev` profile [unoptimized + debuginfo] target(s) in 0.06s
     Running `target/debug/xtask --fast`
Running script: typos
Minimizing JSON file: etc/grafana/dashboards/node-exporter-full.json
Minimizing JSON file: etc/grafana/dashboards/foyer.json
Running script: cargo sort -w
Checking foyer...
Finished: Cargo.toml for "foyer" has been rewritten
Checking examples...
thread 'main' panicked at ~/.cargo/registry/src/index.crates.io-6f17d22bba15001f/cargo-sort-1.0.9/src/sort.rs:113:46:
called `Result::unwrap()` on an `Err` value: TomlError { message: "TOML parse error at line 13, column 8\n   |\n13 | exclude.workspace = true\n   |        ^\nUnexpected `.`\nExpected `=`\n" }
note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace
Script `cargo sort -w` failed.
```

```
$ cargo --version
cargo 1.89.0 (c24e10642 2025-06-23)
```

Hence I couldn't run it and therefore didn't check the checkbox for it above. But that issue is completely unrelated to this PR anyway. The normal tests run just fine of course.