### PR TITLE
fix: fix issue with untrimmed string while parsing throttle

### DIFF
--- a/foyer-storage/src/io/device/throttle.rs
+++ b/foyer-storage/src/io/device/throttle.rs
@@ -138,13 +138,16 @@ mod tests {
 
     #[test]
     fn test_throttle_default() {
-        assert!(matches!(Throttle::new(), Throttle {
-            write_iops: None,
-            read_iops: None,
-            write_throughput: None,
-            read_throughput: None,
-            iops_counter: IopsCounter::PerIo,
-        }));
+        assert!(matches!(
+            Throttle::new(),
+            Throttle {
+                write_iops: None,
+                read_iops: None,
+                write_throughput: None,
+                read_throughput: None,
+                iops_counter: IopsCounter::PerIo,
+            }
+        ));
     }
 
     #[test]
@@ -156,10 +159,22 @@ mod tests {
 
         let _num = NonZeroUsize::new(1024).unwrap();
 
-        assert!(matches!(IopsCounter::from_str("PerIoSize(1024)"), Ok(IopsCounter::PerIoSize(_num))));
-        assert!(matches!(IopsCounter::from_str(" PerIoSize(1024) "), Ok(IopsCounter::PerIoSize(_num))));
-        assert!(matches!(IopsCounter::from_str("PerIoSize(1024) "), Ok(IopsCounter::PerIoSize(_num))));
-        assert!(matches!(IopsCounter::from_str(" PerIoSize(1024)"), Ok(IopsCounter::PerIoSize(_num))));
+        assert!(matches!(
+            IopsCounter::from_str("PerIoSize(1024)"),
+            Ok(IopsCounter::PerIoSize(_num))
+        ));
+        assert!(matches!(
+            IopsCounter::from_str(" PerIoSize(1024) "),
+            Ok(IopsCounter::PerIoSize(_num))
+        ));
+        assert!(matches!(
+            IopsCounter::from_str("PerIoSize(1024) "),
+            Ok(IopsCounter::PerIoSize(_num))
+        ));
+        assert!(matches!(
+            IopsCounter::from_str(" PerIoSize(1024)"),
+            Ok(IopsCounter::PerIoSize(_num))
+        ));
 
         assert!(IopsCounter::from_str("PerIoSize(0)").is_err());
         assert!(IopsCounter::from_str("PerIoSize(1024a)").is_err());


### PR DESCRIPTION
## What's changed, and what's your intention?

It's a minor issue related to parsing PerIoSize. The closed parenthesis was supposed to be the last symbol of the untrimmed string slice. I've added a relevant test to ensure that it behaves as expected

Plus some minor changes that remove unnecessary code related to `Default` implementations.

## Checklist

- [x] I have written the necessary rustdoc comments
- [x] I have added the necessary unit tests and integration tests
- [x] I have passed `cargo x` (or `cargo x --fast` instead if the old tests are not modified) in my local environment.

## Related issues or PRs (optional)
