### PR TITLE
chore: reduce task spawning during recovery

### DIFF
--- a/foyer-common/src/properties.rs
+++ b/foyer-common/src/properties.rs
@@ -25,19 +25,15 @@ use std::fmt::Debug;
 /// For more details, please refer to the document of each enum options.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+#[derive(Default)]
 pub enum Hint {
     /// The default hint shared by all cache eviction algorithms.
+    #[default]
     Normal,
     /// Suggest the priority of the entry is low.
     ///
     /// Used by LRU.
     Low,
-}
-
-impl Default for Hint {
-    fn default() -> Self {
-        Self::Normal
-    }
 }
 
 // TODO(MrCroxx): Is it necessary to make popluated entry still follow the cache location advice?
@@ -83,17 +79,13 @@ pub struct Populated {
 /// Entry source used by hybrid cache.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
+#[derive(Default)]
 pub enum Source {
     /// Comes from outer system of foyer.
+    #[default]
     Outer,
     /// Populated from the disk cache.
     Populated(Populated),
-}
-
-impl Default for Source {
-    fn default() -> Self {
-        Self::Outer
-    }
 }
 
 /// Entry level properties trait.

--- a/foyer-memory/src/eviction/lfu.rs
+++ b/foyer-memory/src/eviction/lfu.rs
@@ -67,18 +67,13 @@ impl Default for LfuConfig {
     }
 }
 
-#[derive(Debug, PartialEq, Eq, Clone, Copy)]
+#[derive(Debug, PartialEq, Eq, Clone, Copy, Default)]
 enum Queue {
+    #[default]
     None,
     Window,
     Probation,
     Protected,
-}
-
-impl Default for Queue {
-    fn default() -> Self {
-        Self::None
-    }
 }
 
 /// w-TinyLFU eviction algorithm hint.

--- a/foyer-memory/src/eviction/s3fifo.rs
+++ b/foyer-memory/src/eviction/s3fifo.rs
@@ -56,17 +56,12 @@ impl Default for S3FifoConfig {
     }
 }
 
-#[derive(Debug, PartialEq, Eq)]
+#[derive(Debug, PartialEq, Eq, Default)]
 enum Queue {
+    #[default]
     None,
     Main,
     Small,
-}
-
-impl Default for Queue {
-    fn default() -> Self {
-        Self::None
-    }
 }
 
 /// S3Fifo eviction algorithm hint.

--- a/foyer-storage/src/engine/block/engine.rs
+++ b/foyer-storage/src/engine/block/engine.rs
@@ -376,7 +376,7 @@ where
             self.recover_concurrency,
             recover_mode,
             self.blob_index_size,
-            &(0..blocks as BlockId).collect_vec(),
+            (0..blocks as BlockId).collect_vec(),
             &sequence,
             &indexer,
             &block_manager,

--- a/foyer/src/hybrid/cache.rs
+++ b/foyer/src/hybrid/cache.rs
@@ -173,18 +173,13 @@ impl Properties for HybridCacheProperties {
 }
 
 /// Control the cache policy of the hybrid cache.
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize, Default)]
 pub enum HybridCachePolicy {
     /// Write disk cache on entry eviction. (Default)
+    #[default]
     WriteOnEviction,
     /// Write disk cache on entry insertion.
     WriteOnInsertion,
-}
-
-impl Default for HybridCachePolicy {
-    fn default() -> Self {
-        Self::WriteOnEviction
-    }
 }
 
 pub struct HybridCachePipe<K, V, S>


### PR DESCRIPTION
## What's changed and what's your intention?

Spawning too many tasks(one for each block) will introduce extra scheduling overhead. It's better to spawn tasks on demand.

## Checklist

- [x] I have written the necessary rustdoc comments
- [x] I have added the necessary unit tests and integration tests
- [x] I have passed `cargo x` (or `cargo x --fast` instead if the old tests are not modified) in my local environment.

## Related issues or PRs (optional)
