### PR TITLE
refactor: use foyer defined result type for memory get_or_fetch()

### DIFF
--- a/foyer-memory/src/cache.rs
+++ b/foyer-memory/src/cache.rs
@@ -26,7 +26,7 @@ use pin_project::pin_project;
 use serde::{Deserialize, Serialize};
 
 use crate::{
-    error::Result,
+    error::{Error, Result},
     eviction::{
         fifo::{Fifo, FifoConfig},
         lfu::{Lfu, LfuConfig},
@@ -1005,10 +1005,11 @@ where
     P: Properties,
     C: Any + Send + Sync + 'static,
 {
-    type Output = std::result::Result<CacheEntry<K, V, S, P>, Box<dyn std::error::Error + Send + Sync>>;
+    type Output = Result<CacheEntry<K, V, S, P>>;
 
     fn poll(self: std::pin::Pin<&mut Self>, cx: &mut std::task::Context<'_>) -> std::task::Poll<Self::Output> {
-        self.poll_inner(cx).map(|res| res.map(|opt| opt.unwrap()))
+        self.poll_inner(cx)
+            .map(|res| res.map(|opt| opt.unwrap()).map_err(Error::other))
     }
 }
 

--- a/foyer-memory/src/error.rs
+++ b/foyer-memory/src/error.rs
@@ -35,8 +35,8 @@ impl Error {
     }
 
     /// Other error.
-    pub fn other(err: impl std::error::Error + Send + Sync + 'static) -> Self {
-        Self::Other(Box::new(err))
+    pub fn other(e: impl Into<Box<dyn std::error::Error + Send + Sync + 'static>>) -> Self {
+        Self::Other(e.into())
     }
 }
 

--- a/foyer/src/hybrid/cache.rs
+++ b/foyer/src/hybrid/cache.rs
@@ -841,6 +841,7 @@ where
     S: HashBuilder + Debug,
 {
     type Output = Result<Option<HybridCacheEntry<K, V, S>>>;
+
     fn poll(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Self::Output> {
         let this = self.project();
 

--- a/foyer/src/hybrid/error.rs
+++ b/foyer/src/hybrid/error.rs
@@ -28,10 +28,7 @@ pub enum Error {
 
 impl Error {
     /// Create customized error.
-    pub fn other<E>(e: E) -> Self
-    where
-        E: Into<Box<dyn std::error::Error + Send + Sync + 'static>>,
-    {
+    pub fn other(e: impl Into<Box<dyn std::error::Error + Send + Sync + 'static>>) -> Self {
         Self::Other(e.into())
     }
 


### PR DESCRIPTION
## What's changed and what's your intention?

> Please explain **IN DETAIL** what the changes are in this PR and why they are needed. :D

AS IS

## Checklist

- [x] I have written the necessary rustdoc comments
- [x] I have added the necessary unit tests and integration tests
- [x] I have passed `cargo x` (or `cargo x --fast` instead if the old tests are not modified) in my local environment.

## Related issues or PRs (optional)
