### PR TITLE
fix: remove `unwrap` in `FsDeviceBuilder::build`

### DIFF
--- a/foyer-storage/src/io/device/fs.rs
+++ b/foyer-storage/src/io/device/fs.rs
@@ -81,11 +81,12 @@ impl DeviceBuilder for FsDeviceBuilder {
 
         let align_v = |value: usize, align: usize| value - value % align;
 
-        let capacity = self.capacity.unwrap_or({
+        let capacity = self.capacity.map(Ok::<_, IoError>).unwrap_or({
             // Create an empty directory before to get free space.
-            create_dir_all(&self.dir).unwrap();
-            free_space(&self.dir).unwrap() as usize / 10 * 8
-        });
+            create_dir_all(&self.dir)?;
+            Ok(free_space(&self.dir)? as usize / 10 * 8)
+        })?;
+
         let capacity = align_v(capacity, PAGE);
 
         let statistics = Arc::new(Statistics::new(self.throttle));


### PR DESCRIPTION
## What's changed and what's your intention?

Remove `unwrap` in `FsDeviceBuilder::build`.

## Checklist

- [x] I have written the necessary rustdoc comments
- [x] I have added the necessary unit tests and integration tests
- [x] I have passed `cargo x` (or `cargo x --fast` instead if the old tests are not modified) in my local environment.

## Related issues or PRs (optional)

N/A.
