### PR TITLE
refactor: loose get_or_fetch() closure trait bounds

### DIFF
--- a/foyer-memory/src/cache.rs
+++ b/foyer-memory/src/cache.rs
@@ -1090,7 +1090,7 @@ where
     pub fn get_or_fetch<Q, F, FU, IT>(&self, key: &Q, fetch: F) -> GetOrFetch<K, V, S, P>
     where
         Q: Hash + Equivalent<K> + ?Sized + ToOwned<Owned = K>,
-        F: FnOnce(&K) -> FU + Send + 'static,
+        F: FnOnce(&Q) -> FU,
         FU: Future<Output = Result<IT>> + Send + 'static,
         IT: Into<FetchTarget<K, V, P>>,
     {


### PR DESCRIPTION
## What's changed and what's your intention?

> Please explain **IN DETAIL** what the changes are in this PR and why they are needed. :D

After #1177 , the closure that `get_or_fetch()` acceptes requires `Send + 'static` bounds, which make it very inconvenient for user to call and cannot avoid context cloning.

This PR looses `get_or_fetch()` closure trait bounds.

Create future on calling, since in most cases ctx needs to be cloned anyway.

This only affects user-face APIs, not foyer internal APIs, so there shouldb't be new introduced concurrency problem. And keeps the internal `ctx` operating order the same.

## Checklist

- [x] I have written the necessary rustdoc comments
- [x] I have added the necessary unit tests and integration tests
- [x] I have passed `cargo x` (or `cargo x --fast` instead if the old tests are not modified) in my local environment.

## Related issues or PRs (optional)
#1177 