### PR TITLE
refactor: refine get_or_fetch closure args

### DIFF
--- a/.typos.toml
+++ b/.typos.toml
@@ -1,6 +1,8 @@
 [default.extend-words]
 # "ot" short for "OpenTelemetry"
 ot = "ot"
+fo = "fo"
+fr = "fr"
 
 [files]
 extend-exclude = ["foyer-workspace-hack/Cargo.toml", "*.svg"]

--- a/README.md
+++ b/README.md
@@ -213,7 +213,7 @@ async fn main() -> anyhow::Result<()> {
     );
 
     let e = hybrid
-        .get_or_fetch(&20230512, |_| async {
+        .get_or_fetch(&20230512, || async {
             // Mock fetching data from remote source
             let now = chrono::Utc::now();
             if format!("{}{}{}", now.year(), now.month(), now.day()) == "20230512" {

--- a/examples/hybrid_full.rs
+++ b/examples/hybrid_full.rs
@@ -89,7 +89,7 @@ async fn main() -> anyhow::Result<()> {
     );
 
     let e = hybrid
-        .get_or_fetch(&20230512, |_| async {
+        .get_or_fetch(&20230512, || async {
             // Mock fetching data from remote source
             let now = chrono::Utc::now();
             if format!("{}{}{}", now.year(), now.month(), now.day()) == "20230512" {

--- a/foyer/tests/hybrid_cache_fuzzy_test.rs
+++ b/foyer/tests/hybrid_cache_fuzzy_test.rs
@@ -184,11 +184,11 @@ async fn fetch(hybrid: HybridCache<u64, Vec<u8>>, recent: Arc<RecentEvictionQueu
 
         let res = if cnt % ERROR_PER_FETCHES as u64 == 0 {
             hybrid
-                .get_or_fetch(&key, move |_| async move { Err::<Vec<u8>, _>(Trap) })
+                .get_or_fetch(&key, || async move { Err::<Vec<u8>, _>(Trap) })
                 .await
         } else {
             hybrid
-                .get_or_fetch(&key, move |_| async move {
+                .get_or_fetch(&key, || async move {
                     tokio::time::sleep(MISS_WAIT).await;
                     Ok::<_, Error>(value(key))
                 })


### PR DESCRIPTION
## What's changed and what's your intention?

> Please explain **IN DETAIL** what the changes are in this PR and why they are needed. :D

Remove `key: &K` from the argument list of the closure in `get_or_fetch()` API.

The argument was useful when the closure will be run optionally and delaied with `Send + 'static` bounds. But #1203 proved it is useless and loosed the bound, let restore the argument list of the closure, too.

## Checklist

- [x] I have written the necessary rustdoc comments
- [x] I have added the necessary unit tests and integration tests
- [x] I have passed `cargo x` (or `cargo x --fast` instead if the old tests are not modified) in my local environment.

## Related issues or PRs (optional)
#1203