### PR TITLE
fix(storage): Avoid use of uninitialised memory

### DIFF
--- a/foyer-storage/src/io/bytes.rs
+++ b/foyer-storage/src/io/bytes.rs
@@ -64,6 +64,11 @@ unsafe impl Sync for Raw {}
 
 impl Raw {
     /// Allocate an 4K-aligned [`Raw`] with **AT LEAST** `capacity` bytes.
+    ///
+    /// # Safety
+    ///
+    /// The returned buffer contains uninitialized memory. Callers must initialize
+    /// the memory before reading from it to avoid undefined behavior.
     pub fn new(capacity: usize) -> Self {
         let capacity = bits::align_up(PAGE, capacity);
         let layout = unsafe { Layout::from_size_align_unchecked(capacity, PAGE) };


### PR DESCRIPTION
## What's changed and what's your intention?

Avoid use of uninitialised memory in storage, by being careful when creating the checksum, and implementing a custom `PartialEq`.

It is possible that none of these problems could occur via typical use of `foyer`, and there are no other crates.io published uses of foyer-storage according to https://crates.io/crates/foyer-storage/reverse_dependencies .

## Checklist

- [ ] I have written the necessary rustdoc comments
- [ ] I have added the necessary unit tests and integration tests
- [ ] I have passed `cargo x` (or `cargo x --fast` instead if the old tests are not modified) in my local environment.

## Related issues or PRs (optional)

Fixes #1223 