### PR TITLE
feat: exposes false positive metrics

### DIFF
--- a/foyer-common/src/metrics.rs
+++ b/foyer-common/src/metrics.rs
@@ -40,6 +40,7 @@ pub struct Metrics {
     pub storage_throttled: BoxedCounter,
     pub storage_delete: BoxedCounter,
     pub storage_error: BoxedCounter,
+    pub storage_false_positive: BoxedCounter,
 
     pub storage_enqueue_duration: BoxedHistogram,
     pub storage_hit_duration: BoxedHistogram,
@@ -230,6 +231,7 @@ impl Metrics {
         let storage_delete = foyer_storage_op_total.counter(&[name.clone(), "delete".into()]);
         let storage_throttled = foyer_storage_op_total.counter(&[name.clone(), "throttled".into()]);
         let storage_error = foyer_storage_op_total.counter(&[name.clone(), "error".into()]);
+        let storage_false_positive = foyer_storage_op_total.counter(&[name.clone(), "false_positive".into()]);
 
         let storage_enqueue_duration = foyer_storage_op_duration.histogram(&[name.clone(), "enqueue".into()]);
         let storage_hit_duration = foyer_storage_op_duration.histogram(&[name.clone(), "hit".into()]);
@@ -329,6 +331,7 @@ impl Metrics {
             storage_throttled,
             storage_delete,
             storage_error,
+            storage_false_positive,
             storage_enqueue_duration,
             storage_hit_duration,
             storage_miss_duration,


### PR DESCRIPTION
## What's changed and what's your intention?

## 1. Metrics Layer
**File:** `foyer-common/src/metrics.rs`

* **New Counter:** Added `storage_false_positive` to the `Metrics` struct.
* **Registration:** This metric is registered as part of the `foyer_storage_op_total` family, specifically using the label `op="false_positive"`.
* **Initialization:** The counter is instantiated in `Metrics::new` and attached to the global metrics instance, ensuring it is ready for use immediately upon startup.

---

## 2. Storage Logic
**File:** `foyer-storage/src/store.rs`

I updated the `load` function to intercept lookup results and detect collisions.

### The Logic Split
Previously, the code did not distinguish between a "lookup failure" (entry not found) and a "key mismatch" (hash found, entry found, but keys don't match). I split the match arm to specifically catch the case where `load` returns an entry (e.g., `Ok(Load::Entry)` or `Ok(Load::Piece)`), but the higher-level logic determines it is not the correct key.



### Dual Counting
When a collision occurs, the system now performs the following updates:

1.  **`storage_miss`** is incremented (as the operation failed to retrieve the requested data).
2.  **`storage_false_positive`** is **also** incremented.

This allows us to see what percentage of our total "misses" are actually caused by hash collisions rather than the data simply being absent.

---

## 3. Maintenance & Fixes
**File:** `foyer-storage/src/store.rs`

* **Test Compilation:** Fixed a conditional compilation issue with `LoadThrottleSwitch`.
* **Change:** Updated the configuration attribute:
    ```rust
    // Before
    #[cfg(feature = "test_utils")]

    // After
    #[cfg(any(test, feature = "test_utils"))]
    ```
* **Reason:** This ensures the import is available during standard unit tests (`cargo test`), not just when the specific feature flag is manually enabled.
## Checklist

- [x] I have written the necessary rustdoc comments
- [x] I have added the necessary unit tests and integration tests
- [x] I have passed `cargo x` (or `cargo x --fast` instead if the old tests are not modified) in my local environment.

## Related issues or PRs (optional)

https://github.com/foyer-rs/foyer/issues/607