### PR TITLE
fix(storage): delete stale entry if admission rejects update

### DIFF
--- a/foyer-storage/src/test_utils.rs
+++ b/foyer-storage/src/test_utils.rs
@@ -204,6 +204,16 @@ impl Switch {
     }
 }
 
+impl StorageFilterCondition for Switch {
+    fn filter(&self, _: &Arc<Statistics>, _: u64, _: usize) -> StorageFilterResult {
+        if self.is_on() {
+            StorageFilterResult::Admit
+        } else {
+            StorageFilterResult::Reject
+        }
+    }
+}
+
 #[derive(Debug, Default)]
 struct HolderInner {
     holdees: Vec<oneshot::Sender<()>>,


### PR DESCRIPTION
## What's changed and what's your intention?

when the admission rejects the update, explicitly delete the stale data, this case wasn't covered in the old code

## Checklist

- [x] I have written the necessary rustdoc comments
- [x] I have added the necessary unit tests and integration tests
- [x] I have passed `cargo x` (or `cargo x --fast` instead if the old tests are not modified) in my local environment.

## Related issues or PRs (optional)

https://github.com/foyer-rs/foyer/issues/743
