### PR TITLE
fix: fix stale tracing/debug info naming

### DIFF
--- a/foyer-storage/src/engine/block/engine.rs
+++ b/foyer-storage/src/engine/block/engine.rs
@@ -493,7 +493,7 @@ where
     P: Properties,
 {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        f.debug_struct("GenericStore").finish()
+        f.debug_struct("BlockEngine").finish()
     }
 }
 
@@ -568,7 +568,7 @@ where
         .boxed()
     }
 
-    #[cfg_attr(feature = "tracing", trace(name = "foyer::storage::engine::block::generic::enqueue"))]
+    #[cfg_attr(feature = "tracing", trace(name = "foyer::storage::engine::block::engine::enqueue"))]
     fn enqueue(&self, piece: PieceRef<K, V, P>, estimated_size: usize) {
         if !self.inner.active.load(Ordering::Relaxed) {
             tracing::warn!("cannot enqueue new entry after closed");
@@ -715,7 +715,7 @@ where
         };
         #[cfg(feature = "tracing")]
         let load = load.in_span(Span::enter_with_local_parent(
-            "foyer::storage::engine::block::generic::load",
+            "foyer::storage::engine::block::engine::load",
         ));
         load
     }


### PR DESCRIPTION
## What's changed and what's your intention?

> Please explain **IN DETAIL** what the changes are in this PR and why they are needed. :D

AS IS

## Checklist

- [x] I have written the necessary rustdoc comments
- [x] I have added the necessary unit tests and integration tests
- [x] I have passed `cargo x` (or `cargo x --fast` instead if the old tests are not modified) in my local environment.

## Related issues or PRs (optional)
