### PR TITLE
fix: Make `HybridCache::is_hybrid()` correctly return `false` when storage is not configured

### DIFF
--- a/foyer-storage/src/store.rs
+++ b/foyer-storage/src/store.rs
@@ -12,14 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use std::{
-    any::{Any, TypeId},
-    borrow::Cow,
-    fmt::Debug,
-    hash::Hash,
-    sync::Arc,
-    time::Instant,
-};
+use std::{any::Any, borrow::Cow, fmt::Debug, hash::Hash, sync::Arc, time::Instant};
 
 use equivalent::Equivalent;
 use foyer_common::{
@@ -313,7 +306,7 @@ where
 
     /// If the disk cache is enabled.
     pub fn is_enabled(&self) -> bool {
-        self.inner.engine.type_id() != TypeId::of::<Arc<NoopEngine<K, V, P>>>()
+        !(self.inner.engine.as_ref() as &dyn Any).is::<NoopEngine<K, V, P>>()
     }
 }
 

--- a/foyer/src/hybrid/cache.rs
+++ b/foyer/src/hybrid/cache.rs
@@ -1082,6 +1082,35 @@ mod tests {
     }
 
     #[test_log::test(tokio::test)]
+    async fn test_is_hybrid_with_disk_cache() {
+        let dir = tempfile::tempdir().unwrap();
+
+        let cache = HybridCacheBuilder::<u8, u8>::new()
+            .memory(1)
+            .storage()
+            .with_engine_config(BlockEngineConfig::new(
+                FsDeviceBuilder::new(dir).with_capacity(1).build().unwrap(),
+            ))
+            .build()
+            .await
+            .unwrap();
+
+        assert!(cache.is_hybrid());
+    }
+
+    #[test_log::test(tokio::test)]
+    async fn test_is_hybrid_without_disk_cache() {
+        let cache = HybridCacheBuilder::<u8, u8>::new()
+            .memory(1)
+            .storage()
+            .build()
+            .await
+            .unwrap();
+
+        assert!(!cache.is_hybrid());
+    }
+
+    #[test_log::test(tokio::test)]
     async fn test_hybrid_cache() {
         let dir = tempfile::tempdir().unwrap();
 


### PR DESCRIPTION
## What's changed and what's your intention?

`HybridCache::is_hybrid()` presently returns `true` in all circumstances, even when storage is not configured. It is supposed to return `false` when storage is not configured.

This test, which I added in bd866eec, fails in main currently:
```rust
    #[test_log::test(tokio::test)]
    async fn test_is_hybrid_without_disk_cache() {
        let cache = HybridCacheBuilder::<u8, u8>::new()
            .memory(1)
            .storage()
            .build()
            .await
            .unwrap();

        assert!(!cache.is_hybrid());
    }
```

`HybridCache::is_hybrid()` is this:
```rust
    pub fn is_hybrid(&self) -> bool {
        self.inner.storage.is_enabled()
    }
 ```
This is `Store::is_enabled()`:
```rust
     pub fn is_enabled(&self) -> bool {
        self.inner.engine.type_id() != TypeId::of::<Arc<NoopEngine<K, V, P>>>()
     }
```
The problem with `is_enabled()` is that `self.inner.engine` is `Arc<dyn Engine<K, V, P>>` but `Any::type_id()` _does not downcast_---which means there are no circumstances where `self.inner.engine.type_id()` could return something equal to  `TypeId::of::<Arc<NoopEngine<K, V, P>>>()`.

The correct thing to do here is upcast the `Arc`'s referent to a `&dyn Any` and then check if the concrete type is a `NoopEngine<K, V, P>`:

```rust   
    pub fn is_enabled(&self) -> bool {
        !(self.inner.engine.as_ref() as &dyn Any).is::<NoopEngine<K, V, P>>()
     }
```

I've also provided a test for the case where a disk cache is in use, to ensure `is_hybrid()` returns `true` there.

## Checklist

- [x] I have written the necessary rustdoc comments
- [x] I have added the necessary unit tests and integration tests
- [x] I have passed `cargo x` (or `cargo x --fast` instead if the old tests are not modified) in my local environment.