### PR TITLE
fix: Short-circuit fetch on insert

### DIFF
--- a/foyer-memory/src/inflight.rs
+++ b/foyer-memory/src/inflight.rs
@@ -207,18 +207,18 @@ where
                 let (tx, rx) = oneshot::channel();
                 let id = self.next_id;
                 self.next_id += 1;
+                let close = Arc::new(AtomicBool::new(false));
                 let entry = InflightEntry {
                     hash,
                     key: key.to_owned(),
                     inflight: Inflight {
                         id,
-                        close: Arc::new(AtomicBool::new(false)),
+                        close: close.clone(),
                         notifiers: vec![tx],
                         f: None,
                     },
                 };
                 v.insert(entry);
-                let close = Arc::new(AtomicBool::new(false));
                 Enqueue::Lead {
                     id,
                     close,

--- a/foyer-memory/src/raw.rs
+++ b/foyer-memory/src/raw.rs
@@ -1786,6 +1786,71 @@ mod tests {
         test_resize(&cache);
     }
 
+    /// Test that a cache insert will interrupt get_or_fetch's underlying fetch if already in progress
+    #[tokio::test]
+    async fn test_insert_closes_inflight_fetch() {
+        use std::pin::pin;
+
+        use tokio::sync::Notify;
+
+        let cache = fifo_cache_for_test();
+        let key: u64 = 42;
+
+        let fetch_running = Arc::new(Notify::new());
+        let fetch_dropped = Arc::new(Notify::new());
+
+        // start a get_or_fetch with a fetch that yields forever and cannot resolve.
+        let get_or_fetch = cache.get_or_fetch(&key, {
+            let fetch_running = fetch_running.clone();
+            let fetch_dropped = fetch_dropped.clone();
+            move || {
+                async move {
+                    // notify fetch_dropped when this future is dropped.
+                    struct DropNotify(Arc<Notify>);
+                    impl Drop for DropNotify {
+                        fn drop(&mut self) {
+                            self.0.notify_one();
+                        }
+                    }
+                    let _guard = DropNotify(fetch_dropped);
+
+                    // signal that the fetch future is now executing.
+                    fetch_running.notify_one();
+
+                    // yield forever, this future can never resolve.
+                    loop {
+                        tokio::task::yield_now().await;
+                    }
+
+                    #[expect(unreachable_code)]
+                    Ok::<_, anyhow::Error>(42)
+                }
+            }
+        });
+
+        // start polling the get to trigger work
+        let cx = &mut std::task::Context::from_waker(std::task::Waker::noop());
+        let mut get_or_fetch = pin!(get_or_fetch);
+        assert!(get_or_fetch.as_mut().poll(cx).is_pending());
+
+        // wait until the spawned fetch has begun
+        fetch_running.notified().await;
+
+        // now insert the same key directly. this should short-circuit inflight fetches
+        cache.insert(key, 100);
+
+        // the get should now resolve
+        assert_eq!(*get_or_fetch.await.unwrap().unwrap().value(), 100);
+
+        // The fetch future is in a yield loop, so it will be re-polled by the runtime.
+        // Notification handling should short-circuit the fetch and drop it
+
+        // Await the drop notification with a timeout.
+        let drop_result = tokio::time::timeout(std::time::Duration::from_secs(1), fetch_dropped.notified()).await;
+
+        assert!(drop_result.is_ok(), "fetch future was not dropped within timeout");
+    }
+
     mod fuzzy {
         use foyer_common::properties::Hint;
 


### PR DESCRIPTION
## What's changed and what's your intention?

> Please explain **IN DETAIL** what the changes are in this PR and why they are needed. :D

There was a bug in the inflight tracking where the `close` boolean was duplicated instead of cloned. This could result in fetch futures running in the background even though all the waiters were already resolved.

## Checklist

- [x] I have written the necessary rustdoc comments
- [x] I have added the necessary unit tests and integration tests
- [x] I have passed `cargo x` (or `cargo x --fast` instead if the old tests are not modified) in my local environment.

## Related issues or PRs (optional)
