### PR TITLE
fix: make `SieveConfig` available through the foyer crate

### DIFF
--- a/foyer-memory/src/prelude.rs
+++ b/foyer-memory/src/prelude.rs
@@ -16,7 +16,7 @@
 pub use crate::eviction::test_utils::TestProperties;
 pub use crate::{
     cache::{Cache, CacheBuilder, CacheEntry, CacheProperties, EvictionConfig, GetOrFetch},
-    eviction::{Eviction, Op, fifo::FifoConfig, lfu::LfuConfig, lru::LruConfig, s3fifo::S3FifoConfig},
+    eviction::{Eviction, Op, fifo::FifoConfig, lfu::LfuConfig, lru::LruConfig, s3fifo::S3FifoConfig, sieve::SieveConfig},
     inflight::{
         FetchTarget, Notifier, OptionalFetch, OptionalFetchBuilder, RequiredFetch, RequiredFetchBuilder,
         RequiredFetchBuilderErased, Waiter,

--- a/foyer/src/prelude.rs
+++ b/foyer/src/prelude.rs
@@ -33,7 +33,7 @@ pub use crate::{
     },
     memory::{
         Cache, CacheBuilder, CacheEntry, CacheProperties, EvictionConfig, FifoConfig, Filter, GetOrFetch, LfuConfig,
-        LruConfig, S3FifoConfig, Weighter,
+        LruConfig, S3FifoConfig, Weighter, SieveConfig
     },
     storage::{
         AdmitAll, Block, BlockEngineConfig, BlockStatistics, CombinedDeviceBuilder, Compression, Device, DeviceBuilder,


### PR DESCRIPTION
## What's changed and what's your intention?
Currently `SieveConfig` is the only evicition config that is not routed through the project structure, which makes it difficult to use (`Default::default()` might work, as it is implemented and avoids naming the struct, but I haven't tried). This seems like a small oversight, so this PR fixes it :)

## Checklist

- [ ] I have written the necessary rustdoc comments
- [ ] I have added the necessary unit tests and integration tests
-> No business logic change
- [ ] I have passed `cargo x` (or `cargo x --fast` instead if the old tests are not modified) in my local environment.
-> Couldn't in the github editor and I would be very suprised if this broke anything
Let me know if I should do any of the above anyways :)
