### PR TITLE
perf(storage): Reduce block recovery index overhead

### DIFF
--- a/foyer-storage/src/engine/block/indexer.rs
+++ b/foyer-storage/src/engine/block/indexer.rs
@@ -17,6 +17,7 @@ use std::{
     sync::Arc,
 };
 
+use foyer_common::hasher::ModHasher;
 use itertools::Itertools;
 use parking_lot::RwLock;
 
@@ -52,7 +53,7 @@ pub struct EntryAddress {
     pub sequence: Sequence,
 }
 
-type IndexerShard = HashMap<u64, Index>;
+type IndexerShard = HashMap<u64, Index, ModHasher>;
 
 /// [`Indexer`] records key hash to entry address on fs.
 #[derive(Debug, Clone)]
@@ -62,7 +63,9 @@ pub struct Indexer {
 
 impl Indexer {
     pub fn new(shards: usize) -> Self {
-        let shards = (0..shards).map(|_| RwLock::new(HashMap::new())).collect_vec();
+        let shards = (0..shards)
+            .map(|_| RwLock::new(HashMap::with_hasher(ModHasher::default())))
+            .collect_vec();
         Self {
             shards: Arc::new(shards),
         }
@@ -83,12 +86,27 @@ impl Indexer {
         fastrace::trace(name = "foyer::storage::block::indexer::insert_batch")
     )]
     pub fn insert_batch(&self, batch: Vec<HashedEntryAddress>) -> Vec<HashedEntryAddress> {
-        let shards: HashMap<usize, Vec<HashedEntryAddress>> =
-            batch.into_iter().into_group_map_by(|haddr| self.shard(haddr.hash));
+        let mut counts = vec![0; self.shards.len()];
+        for haddr in &batch {
+            counts[self.shard(haddr.hash)] += 1;
+        }
+
+        let mut shards = counts.iter().map(|count| Vec::with_capacity(*count)).collect_vec();
+        for haddr in batch {
+            let shard = self.shard(haddr.hash);
+            shards[shard].push(haddr);
+        }
 
         let mut olds = vec![];
-        for (s, batch) in shards {
+        for (s, batch) in shards.into_iter().enumerate() {
+            if batch.is_empty() {
+                continue;
+            }
             let mut shard = self.shards[s].write();
+            let available = shard.capacity().saturating_sub(shard.len());
+            if available < batch.len() {
+                shard.reserve(batch.len() - available);
+            }
             for haddr in batch {
                 if let Some(old) = self.insert_inner(&mut shard, haddr.hash, Index::Address(haddr.address)) {
                     olds.push(HashedEntryAddress {

--- a/foyer-storage/src/engine/block/indexer.rs
+++ b/foyer-storage/src/engine/block/indexer.rs
@@ -17,7 +17,8 @@ use std::{
     sync::Arc,
 };
 
-use foyer_common::hasher::ModHasher;
+use foyer_common::{error::Result, hasher::ModHasher, spawn::Spawner};
+use futures_util::{StreamExt, TryStreamExt, stream};
 use itertools::Itertools;
 use parking_lot::RwLock;
 
@@ -59,15 +60,22 @@ type IndexerShard = HashMap<u64, Index, ModHasher>;
 #[derive(Debug, Clone)]
 pub struct Indexer {
     shards: Arc<Vec<RwLock<IndexerShard>>>,
+    shard_mask: usize,
 }
 
 impl Indexer {
     pub fn new(shards: usize) -> Self {
+        let shard_mask = if shards.is_power_of_two() {
+            shards - 1
+        } else {
+            usize::MAX
+        };
         let shards = (0..shards)
             .map(|_| RwLock::new(HashMap::with_hasher(ModHasher::default())))
             .collect_vec();
         Self {
             shards: Arc::new(shards),
+            shard_mask,
         }
     }
 
@@ -86,6 +94,38 @@ impl Indexer {
         fastrace::trace(name = "foyer::storage::block::indexer::insert_batch")
     )]
     pub fn insert_batch(&self, batch: Vec<HashedEntryAddress>) -> Vec<HashedEntryAddress> {
+        self.partition_batch(batch)
+            .into_iter()
+            .enumerate()
+            .filter(|(_, batch)| !batch.is_empty())
+            .flat_map(|(shard, batch)| self.insert_shard_batch(shard, batch))
+            .collect()
+    }
+
+    pub(super) async fn insert_recovery_batch(
+        &self,
+        batch: Vec<HashedEntryAddress>,
+        concurrency: usize,
+        spawner: Spawner,
+    ) -> Result<()> {
+        let this = self.clone();
+        stream::iter(
+            self.partition_batch(batch)
+                .into_iter()
+                .enumerate()
+                .filter(|(_, batch)| !batch.is_empty())
+                .map(move |(shard, batch)| {
+                    let this = this.clone();
+                    spawner.spawn(async move { this.insert_shard_batch_discard(shard, batch) })
+                }),
+        )
+        .buffer_unordered(concurrency.max(1))
+        .try_collect::<Vec<_>>()
+        .await
+        .map(drop)
+    }
+
+    fn partition_batch(&self, batch: Vec<HashedEntryAddress>) -> Vec<Vec<HashedEntryAddress>> {
         let mut counts = vec![0; self.shards.len()];
         for haddr in &batch {
             counts[self.shard(haddr.hash)] += 1;
@@ -96,27 +136,37 @@ impl Indexer {
             let shard = self.shard(haddr.hash);
             shards[shard].push(haddr);
         }
+        shards
+    }
 
+    fn insert_shard_batch(&self, shard: usize, batch: Vec<HashedEntryAddress>) -> Vec<HashedEntryAddress> {
         let mut olds = vec![];
-        for (s, batch) in shards.into_iter().enumerate() {
-            if batch.is_empty() {
-                continue;
-            }
-            let mut shard = self.shards[s].write();
-            let available = shard.capacity().saturating_sub(shard.len());
-            if available < batch.len() {
-                shard.reserve(batch.len() - available);
-            }
-            for haddr in batch {
-                if let Some(old) = self.insert_inner(&mut shard, haddr.hash, Index::Address(haddr.address)) {
-                    olds.push(HashedEntryAddress {
-                        hash: haddr.hash,
-                        address: old,
-                    });
-                }
+        self.insert_shard_batch_with(shard, batch, |hash, address| {
+            olds.push(HashedEntryAddress { hash, address });
+        });
+        olds
+    }
+
+    fn insert_shard_batch_discard(&self, shard: usize, batch: Vec<HashedEntryAddress>) {
+        self.insert_shard_batch_with(shard, batch, |_, _| {});
+    }
+
+    fn insert_shard_batch_with(
+        &self,
+        shard: usize,
+        batch: Vec<HashedEntryAddress>,
+        mut on_old: impl FnMut(u64, EntryAddress),
+    ) {
+        let mut shard = self.shards[shard].write();
+        let available = shard.capacity().saturating_sub(shard.len());
+        if available < batch.len() {
+            shard.reserve(batch.len());
+        }
+        for haddr in batch {
+            if let Some(old) = self.insert_inner(&mut shard, haddr.hash, Index::Address(haddr.address)) {
+                on_old(haddr.hash, old);
             }
         }
-        olds
     }
 
     #[cfg_attr(feature = "tracing", fastrace::trace(name = "foyer::storage::block::indexer::get"))]
@@ -180,9 +230,30 @@ impl Indexer {
         self.shards.iter().for_each(|shard| shard.write().clear());
     }
 
+    pub(super) fn compact_and_count(&self) -> usize {
+        self.shards
+            .iter()
+            .map(|shard| {
+                let mut shard = shard.write();
+                if shard.capacity() > shard.len().saturating_mul(2) {
+                    shard.shrink_to_fit();
+                }
+                shard.len()
+            })
+            .sum()
+    }
+
     #[inline(always)]
     fn shard(&self, hash: u64) -> usize {
-        hash as usize % self.shards.len()
+        // Select the shard from mixed high bits. `IndexerShard` uses the original hash with `ModHasher`, so reusing
+        // its low bits here would make every key in a shard start in the same group of hash table buckets.
+        const GOLDEN_RATIO: u64 = 0x9e37_79b9_7f4a_7c15;
+        let mixed = (hash.wrapping_mul(GOLDEN_RATIO) >> 32) as usize;
+        if self.shard_mask != usize::MAX {
+            mixed & self.shard_mask
+        } else {
+            mixed % self.shards.len()
+        }
     }
 
     fn insert_inner(&self, shard: &mut IndexerShard, hash: u64, index: Index) -> Option<EntryAddress> {
@@ -207,6 +278,97 @@ impl Indexer {
         match index {
             Index::Address(addr) => Some(addr),
             Index::Tombstone(_) => None,
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::collections::HashSet;
+
+    use super::*;
+
+    fn haddr(hash: u64, sequence: Sequence) -> HashedEntryAddress {
+        HashedEntryAddress {
+            hash,
+            address: EntryAddress {
+                block: 0,
+                offset: 0,
+                len: 1,
+                sequence,
+            },
+        }
+    }
+
+    #[test]
+    fn test_shard_selection_does_not_reuse_hash_low_bits() {
+        let indexer = Indexer::new(64);
+        let mut low_bits = (0..64).map(|_| HashSet::new()).collect_vec();
+        for hash in 0..4096 {
+            low_bits[indexer.shard(hash)].insert(hash & 63);
+        }
+        assert!(low_bits.iter().all(|bits| bits.len() > 16));
+    }
+
+    #[test]
+    fn test_compact_duplicate_heavy_batch() {
+        let indexer = Indexer::new(4);
+        indexer.insert_batch((0..10_000).map(|sequence| haddr(sequence % 10, sequence)).collect());
+
+        let capacity_before = indexer
+            .shards
+            .iter()
+            .map(|shard| shard.read().capacity())
+            .sum::<usize>();
+        assert_eq!(indexer.compact_and_count(), 10);
+        let capacity_after = indexer
+            .shards
+            .iter()
+            .map(|shard| shard.read().capacity())
+            .sum::<usize>();
+
+        assert!(capacity_after < capacity_before);
+        for hash in 0..10 {
+            assert_eq!(indexer.get(hash).unwrap().sequence, 9_990 + hash);
+        }
+    }
+
+    #[test_log::test(tokio::test)]
+    async fn test_recovery_batch_preserves_equal_sequence_order() {
+        let indexer = Indexer::new(4);
+        let mut first = haddr(7, 42);
+        first.address.block = 1;
+        let mut last = haddr(7, 42);
+        last.address.block = 2;
+
+        indexer
+            .insert_recovery_batch(vec![first, haddr(11, 1), last], 4, Spawner::current())
+            .await
+            .unwrap();
+
+        assert_eq!(indexer.get(7).unwrap().block, 2);
+    }
+
+    #[test_log::test(tokio::test)]
+    async fn test_recovery_batch_matches_insert_batch() {
+        let expected = Indexer::new(7);
+        let actual = Indexer::new(7);
+        let batch = (0..10_000)
+            .map(|i| {
+                let mut entry = haddr((i * 31 % 257) as u64, (i * 17 % 101) as Sequence);
+                entry.address.block = i as BlockId;
+                entry
+            })
+            .collect_vec();
+
+        expected.insert_batch(batch.clone());
+        actual
+            .insert_recovery_batch(batch, 8, Spawner::current())
+            .await
+            .unwrap();
+
+        for hash in 0..257 {
+            assert_eq!(actual.get(hash), expected.get(hash));
         }
     }
 }

--- a/foyer-storage/src/engine/block/indexer.rs
+++ b/foyer-storage/src/engine/block/indexer.rs
@@ -93,8 +93,10 @@ impl Indexer {
         feature = "tracing",
         fastrace::trace(name = "foyer::storage::block::indexer::insert_batch")
     )]
-    pub fn insert_batch(&self, batch: Vec<HashedEntryAddress>) -> Vec<HashedEntryAddress> {
-        self.partition_batch(batch)
+    pub fn insert_batch(&self, mut batch: Vec<HashedEntryAddress>) -> Vec<HashedEntryAddress> {
+        let shards = self.partition_batch(&mut batch);
+        drop(batch);
+        shards
             .into_iter()
             .enumerate()
             .filter(|(_, batch)| !batch.is_empty())
@@ -104,7 +106,7 @@ impl Indexer {
 
     pub(super) async fn insert_recovery_batch(
         &self,
-        batch: Vec<HashedEntryAddress>,
+        batch: &mut Vec<HashedEntryAddress>,
         concurrency: usize,
         spawner: Spawner,
     ) -> Result<()> {
@@ -125,14 +127,14 @@ impl Indexer {
         .map(drop)
     }
 
-    fn partition_batch(&self, batch: Vec<HashedEntryAddress>) -> Vec<Vec<HashedEntryAddress>> {
+    fn partition_batch(&self, batch: &mut Vec<HashedEntryAddress>) -> Vec<Vec<HashedEntryAddress>> {
         let mut counts = vec![0; self.shards.len()];
-        for haddr in &batch {
+        for haddr in batch.iter() {
             counts[self.shard(haddr.hash)] += 1;
         }
 
         let mut shards = counts.iter().map(|count| Vec::with_capacity(*count)).collect_vec();
-        for haddr in batch {
+        for haddr in batch.drain(..) {
             let shard = self.shard(haddr.hash);
             shards[shard].push(haddr);
         }
@@ -284,8 +286,6 @@ impl Indexer {
 
 #[cfg(test)]
 mod tests {
-    use std::collections::HashSet;
-
     use super::*;
 
     fn haddr(hash: u64, sequence: Sequence) -> HashedEntryAddress {
@@ -303,11 +303,11 @@ mod tests {
     #[test]
     fn test_shard_selection_does_not_reuse_hash_low_bits() {
         let indexer = Indexer::new(64);
-        let mut low_bits = (0..64).map(|_| HashSet::new()).collect_vec();
+        let mut low_bits = [0u64; 64];
         for hash in 0..4096 {
-            low_bits[indexer.shard(hash)].insert(hash & 63);
+            low_bits[indexer.shard(hash)] |= 1 << (hash & 63);
         }
-        assert!(low_bits.iter().all(|bits| bits.len() > 16));
+        assert!(low_bits.iter().all(|bits| bits.count_ones() > 16));
     }
 
     #[test]
@@ -334,41 +334,38 @@ mod tests {
     }
 
     #[test_log::test(tokio::test)]
-    async fn test_recovery_batch_preserves_equal_sequence_order() {
-        let indexer = Indexer::new(4);
-        let mut first = haddr(7, 42);
-        first.address.block = 1;
-        let mut last = haddr(7, 42);
-        last.address.block = 2;
-
-        indexer
-            .insert_recovery_batch(vec![first, haddr(11, 1), last], 4, Spawner::current())
-            .await
-            .unwrap();
-
-        assert_eq!(indexer.get(7).unwrap().block, 2);
-    }
-
-    #[test_log::test(tokio::test)]
-    async fn test_recovery_batch_matches_insert_batch() {
+    async fn test_recovery_batches_match_insert_batch() {
         let expected = Indexer::new(7);
         let actual = Indexer::new(7);
-        let batch = (0..10_000)
+        let mut batch = (0..10_000)
             .map(|i| {
                 let mut entry = haddr((i * 31 % 257) as u64, (i * 17 % 101) as Sequence);
                 entry.address.block = i as BlockId;
                 entry
             })
             .collect_vec();
+        batch[126] = haddr(u64::MAX, 42);
+        batch[126].address.block = 1;
+        batch[127] = haddr(u64::MAX, 42);
+        batch[127].address.block = 2;
 
         expected.insert_batch(batch.clone());
-        actual
-            .insert_recovery_batch(batch, 8, Spawner::current())
-            .await
-            .unwrap();
+        let mut entries = batch.into_iter();
+        let mut chunk = Vec::with_capacity(127);
+        loop {
+            chunk.extend(entries.by_ref().take(127));
+            if chunk.is_empty() {
+                break;
+            }
+            actual
+                .insert_recovery_batch(&mut chunk, 8, Spawner::current())
+                .await
+                .unwrap();
+        }
 
         for hash in 0..257 {
             assert_eq!(actual.get(hash), expected.get(hash));
         }
+        assert_eq!(actual.get(u64::MAX), expected.get(u64::MAX));
     }
 }

--- a/foyer-storage/src/engine/block/recover.rs
+++ b/foyer-storage/src/engine/block/recover.rs
@@ -13,7 +13,6 @@
 // limitations under the License.
 
 use std::{
-    collections::{HashMap, hash_map::Entry},
     fmt::Debug,
     sync::{Arc, atomic::Ordering},
     time::Instant,
@@ -27,14 +26,14 @@ use foyer_common::{
 use futures_util::{StreamExt, TryStreamExt, stream};
 use itertools::Itertools;
 
-use super::indexer::{EntryAddress, Indexer};
+use super::indexer::Indexer;
 use crate::engine::{
     RecoverMode,
     block::{
         indexer::HashedEntryAddress,
         manager::{Block, BlockId, BlockManager},
         scanner::{BlockScanner, EntryInfo},
-        serde::{AtomicSequence, Sequence},
+        serde::AtomicSequence,
         tombstone::Tombstone,
     },
 };
@@ -79,31 +78,13 @@ impl RecoverRunner {
             return Err(e);
         }
 
-        #[derive(Debug)]
-        enum EntryAddressOrTombstone {
-            EntryAddress(EntryAddress),
-            Tombstone,
-        }
-
-        // Dedup entries.
+        // Install recovered entries into the indexer. The indexer deduplicates by sequence, so recovery does not need
+        // an extra global dedup table.
         let mut latest_sequence = 0;
-        let mut indices: HashMap<u64, (Sequence, EntryAddressOrTombstone)> = HashMap::new();
         let mut clean_blocks = vec![];
         let mut evictable_blocks = vec![];
+        let mut total_entries = 0;
 
-        let mut insert_or_update =
-            |hash: u64, sequence: Sequence, addr: EntryAddressOrTombstone| match indices.entry(hash) {
-                Entry::Occupied(mut entry) => {
-                    let (latest, latest_addr) = entry.get_mut();
-                    if sequence >= *latest {
-                        *latest = sequence;
-                        *latest_addr = addr;
-                    }
-                }
-                Entry::Vacant(entry) => {
-                    entry.insert((sequence, addr));
-                }
-            };
         for (block, infos) in total.into_iter().map(|r| r.unwrap()).enumerate() {
             let block = block as BlockId;
 
@@ -113,37 +94,31 @@ impl RecoverRunner {
                 evictable_blocks.push(block);
             }
 
-            for EntryInfo { hash, addr } in infos {
-                latest_sequence = latest_sequence.max(addr.sequence);
-                insert_or_update(hash, addr.sequence, EntryAddressOrTombstone::EntryAddress(addr));
-            }
+            let indices = infos
+                .into_iter()
+                .map(|EntryInfo { hash, addr }| {
+                    latest_sequence = latest_sequence.max(addr.sequence);
+                    HashedEntryAddress { hash, address: addr }
+                })
+                .collect_vec();
+            total_entries += indices.len();
+            indexer.insert_batch(indices);
         }
         tombstones.iter().for_each(|tombstone| {
             latest_sequence = latest_sequence.max(tombstone.sequence);
-            insert_or_update(tombstone.hash, tombstone.sequence, EntryAddressOrTombstone::Tombstone);
         });
-        let indices = indices
-            .into_iter()
-            .filter_map(|(hash, (sequence, addr))| {
-                tracing::trace!("[recover runner]: hash {hash} has version: {sequence:?} {addr:?}");
-                match addr {
-                    EntryAddressOrTombstone::Tombstone => None,
-                    EntryAddressOrTombstone::EntryAddress(address) => Some(HashedEntryAddress { hash, address }),
-                }
-            })
-            .collect_vec();
+        indexer.remove_batch(tombstones.iter().map(|tombstone| (tombstone.hash, tombstone.sequence)));
 
         // Log recovery.
         tracing::info!(
             "Recovers {e} blocks with data, {c} clean blocks, {t} total entries with max sequence as {s}..",
             e = evictable_blocks.len(),
             c = clean_blocks.len(),
-            t = indices.len(),
+            t = total_entries,
             s = latest_sequence,
         );
 
         // Update components.
-        indexer.insert_batch(indices);
         sequence.store(latest_sequence + 1, Ordering::Release);
         block_manager.init(&clean_blocks);
 

--- a/foyer-storage/src/engine/block/recover.rs
+++ b/foyer-storage/src/engine/block/recover.rs
@@ -13,8 +13,9 @@
 // limitations under the License.
 
 use std::{
-    collections::{HashMap, hash_map::Entry},
+    collections::HashMap,
     fmt::Debug,
+    mem::size_of,
     sync::{Arc, atomic::Ordering},
     time::Instant,
 };
@@ -37,6 +38,10 @@ use crate::engine::{
         tombstone::Tombstone,
     },
 };
+
+// Bound the extra flat and per-shard buffers used while installing recovered entries. Scan results stay intact until
+// all block errors have been aggregated, preserving the existing all-scans-before-indexing behavior.
+const RECOVERY_INDEX_BATCH_BYTES: usize = 32 * 1024 * 1024;
 
 #[derive(Debug)]
 pub struct RecoverRunner;
@@ -91,10 +96,9 @@ impl RecoverRunner {
         .unwrap();
         // Preserve the original input order for error aggregation and equal-sequence replacement.
         total.sort_unstable_by_key(|(order, _)| *order);
-        let total = total.into_iter().map(|(_, result)| result).collect::<Vec<_>>();
 
         // Return error is there is.
-        let (total, errs): (Vec<_>, Vec<_>) = total.into_iter().partition(|res| res.is_ok());
+        let (total, errs): (Vec<_>, Vec<_>) = total.into_iter().map(|(_, result)| result).partition(|res| res.is_ok());
         if !errs.is_empty() {
             let mut e = Error::new(ErrorKind::Recover, "failed to recover blocks");
             for err in errs.into_iter().map(|r| r.unwrap_err()) {
@@ -109,56 +113,57 @@ impl RecoverRunner {
         let mut tombstone_sequences = HashMap::<u64, Sequence>::with_capacity(tombstones.len());
         for tombstone in tombstones {
             latest_sequence = latest_sequence.max(tombstone.sequence);
-            match tombstone_sequences.entry(tombstone.hash) {
-                Entry::Occupied(mut entry) => {
-                    *entry.get_mut() = (*entry.get()).max(tombstone.sequence);
-                }
-                Entry::Vacant(entry) => {
-                    entry.insert(tombstone.sequence);
-                }
-            }
+            tombstone_sequences
+                .entry(tombstone.hash)
+                .and_modify(|sequence| *sequence = (*sequence).max(tombstone.sequence))
+                .or_insert(tombstone.sequence);
         }
 
+        let recovered_blocks = total.len();
         let mut clean_blocks = Vec::with_capacity(total.len());
-        let mut evictable_blocks = 0;
-        let total_entries = total.iter().map(|result| result.as_ref().unwrap().0.len()).sum();
-        let mut indices = Vec::with_capacity(total_entries);
+        let total_entries: usize = total.iter().map(|result| result.as_ref().unwrap().len()).sum();
+        let batch_entries = (RECOVERY_INDEX_BATCH_BYTES / size_of::<HashedEntryAddress>()).max(1);
+        let mut indices = Vec::with_capacity(total_entries.min(batch_entries));
+        let filter_tombstones = !tombstone_sequences.is_empty();
 
-        for (block, (infos, block_latest_sequence)) in total.into_iter().map(|result| result.unwrap()).enumerate() {
+        for (block, infos) in total.into_iter().map(|result| result.unwrap()).enumerate() {
             let block = block as BlockId;
             if infos.is_empty() {
                 clean_blocks.push(block);
-            } else {
-                evictable_blocks += 1;
             }
 
-            latest_sequence = latest_sequence.max(block_latest_sequence);
-            if tombstone_sequences.is_empty() {
-                indices.extend(
-                    infos
-                        .into_iter()
-                        .map(|EntryInfo { hash, addr }| HashedEntryAddress { hash, address: addr }),
-                );
-            } else {
-                indices.extend(infos.into_iter().filter_map(|EntryInfo { hash, addr }| {
-                    tombstone_sequences
+            for EntryInfo { hash, addr } in infos {
+                latest_sequence = latest_sequence.max(addr.sequence);
+                if filter_tombstones
+                    && tombstone_sequences
                         .get(&hash)
-                        .is_none_or(|sequence| addr.sequence > *sequence)
-                        .then_some(HashedEntryAddress { hash, address: addr })
-                }));
+                        .is_some_and(|sequence| addr.sequence <= *sequence)
+                {
+                    continue;
+                }
+
+                indices.push(HashedEntryAddress { hash, address: addr });
+                if indices.len() >= batch_entries {
+                    indexer
+                        .insert_recovery_batch(&mut indices, recover_concurrency, spawner.clone())
+                        .await
+                        .unwrap();
+                }
             }
         }
 
-        indexer
-            .insert_recovery_batch(indices, recover_concurrency, spawner.clone())
-            .await
-            .unwrap();
+        if !indices.is_empty() {
+            indexer
+                .insert_recovery_batch(&mut indices, recover_concurrency, spawner.clone())
+                .await
+                .unwrap();
+        }
         let live_entries = indexer.compact_and_count();
 
         // Log recovery.
         tracing::info!(
             "Recovers {e} blocks with data, {c} clean blocks, {t} scanned entries, {l} live entries with max sequence as {s}..",
-            e = evictable_blocks,
+            e = recovered_blocks - clean_blocks.len(),
             c = clean_blocks.len(),
             t = total_entries,
             l = live_entries,
@@ -184,13 +189,8 @@ impl RecoverRunner {
 struct BlockRecoverRunner;
 
 impl BlockRecoverRunner {
-    async fn run(mode: RecoverMode, block: Block, blob_index_size: usize) -> Result<(Vec<EntryInfo>, Sequence)> {
-        if mode == RecoverMode::None {
-            return Ok((vec![], 0));
-        }
-
+    async fn run(mode: RecoverMode, block: Block, blob_index_size: usize) -> Result<Vec<EntryInfo>> {
         let mut recovered = vec![];
-        let mut latest_sequence = 0;
 
         let id = block.id();
         let mut iter = BlockScanner::new(block, blob_index_size);
@@ -213,105 +213,10 @@ impl BlockRecoverRunner {
                 if info.addr.sequence < recovered.last().map(|last: &EntryInfo| last.addr.sequence).unwrap_or(0) {
                     break 'recover;
                 }
-                latest_sequence = latest_sequence.max(info.addr.sequence);
                 recovered.push(info);
             }
         }
 
-        Ok((recovered, latest_sequence))
-    }
-}
-
-#[cfg(test)]
-mod tests {
-    use std::sync::Arc;
-
-    use foyer_common::{metrics::Metrics, spawn::Spawner};
-    use tempfile::tempdir;
-
-    use super::BlockRecoverRunner;
-    use crate::{
-        Compression,
-        engine::{
-            RecoverMode,
-            block::{
-                buffer::{Buffer, SplitCtx, Splitter},
-                manager::Block,
-            },
-        },
-        io::{
-            bytes::IoSliceMut,
-            device::{DeviceBuilder, fs::FsDeviceBuilder},
-            engine::{IoEngineBuildContext, IoEngineConfig, psync::PsyncIoEngineConfig},
-        },
-    };
-
-    const KB: usize = 1024;
-
-    #[test_log::test(tokio::test)]
-    async fn test_block_recovery_stops_at_out_of_order_sequences() {
-        const BLOCK_SIZE: usize = 64 * KB;
-        const BLOB_INDEX_SIZE: usize = 4 * KB;
-
-        let dir = tempdir().unwrap();
-        let device = FsDeviceBuilder::new(dir.path())
-            .with_capacity(BLOCK_SIZE)
-            .build()
-            .unwrap();
-        let partition = device.create_partition(BLOCK_SIZE).unwrap();
-        let io_engine = PsyncIoEngineConfig::new()
-            .boxed()
-            .build(IoEngineBuildContext {
-                spawner: Spawner::current(),
-            })
-            .await
-            .unwrap();
-
-        let mut buffer = Buffer::new(
-            IoSliceMut::new(BLOCK_SIZE),
-            BLOCK_SIZE - BLOB_INDEX_SIZE,
-            Arc::new(Metrics::noop()),
-        );
-        for (key, sequence) in [2, 0, 1].into_iter().enumerate() {
-            assert!(buffer.push(
-                &(key as u64),
-                &vec![key as u8; 3 * KB],
-                key as u64,
-                Compression::None,
-                sequence,
-            ));
-        }
-
-        let (bytes, infos) = buffer.finish();
-        let mut split = SplitCtx::new(BLOCK_SIZE, BLOB_INDEX_SIZE);
-        let batch = Splitter::split(&mut split, bytes.into_io_slice(), infos);
-        assert_eq!(batch.blocks.len(), 1);
-        assert_eq!(batch.blocks[0].blob_parts.len(), 1);
-        let part = &batch.blocks[0].blob_parts[0];
-
-        let (_, result) = io_engine
-            .write(
-                Box::new(part.data.clone()),
-                partition.as_ref(),
-                part.blob_block_offset as u64 + part.part_blob_offset as u64,
-            )
-            .await;
-        result.unwrap();
-        let (_, result) = io_engine
-            .write(
-                Box::new(part.index.clone()),
-                partition.as_ref(),
-                part.blob_block_offset as u64,
-            )
-            .await;
-        result.unwrap();
-
-        let block = Block::new_for_test(0, partition, io_engine);
-        let (recovered, latest_sequence) = BlockRecoverRunner::run(RecoverMode::Strict, block, BLOB_INDEX_SIZE)
-            .await
-            .unwrap();
-        let sequences = recovered.into_iter().map(|info| info.addr.sequence).collect::<Vec<_>>();
-        assert_eq!(sequences, vec![2]);
-        assert_eq!(latest_sequence, 2);
+        Ok(recovered)
     }
 }

--- a/foyer-storage/src/engine/block/recover.rs
+++ b/foyer-storage/src/engine/block/recover.rs
@@ -13,6 +13,7 @@
 // limitations under the License.
 
 use std::{
+    collections::{HashMap, hash_map::Entry},
     fmt::Debug,
     sync::{Arc, atomic::Ordering},
     time::Instant,
@@ -24,7 +25,6 @@ use foyer_common::{
     spawn::Spawner,
 };
 use futures_util::{StreamExt, TryStreamExt, stream};
-use itertools::Itertools;
 
 use super::indexer::Indexer;
 use crate::engine::{
@@ -33,7 +33,7 @@ use crate::engine::{
         indexer::HashedEntryAddress,
         manager::{Block, BlockId, BlockManager},
         scanner::{BlockScanner, EntryInfo},
-        serde::AtomicSequence,
+        serde::{AtomicSequence, Sequence},
         tombstone::Tombstone,
     },
 };
@@ -57,16 +57,41 @@ impl RecoverRunner {
     ) -> Result<()> {
         let now = Instant::now();
 
+        if recover_mode == RecoverMode::None {
+            let latest_sequence = tombstones
+                .iter()
+                .map(|tombstone| tombstone.sequence)
+                .max()
+                .unwrap_or_default();
+            sequence.store(latest_sequence + 1, Ordering::Release);
+            block_manager.init(&blocks);
+
+            let elapsed = now.elapsed();
+            tracing::info!(
+                "Recovers 0 blocks with data, {c} clean blocks, 0 scanned entries, 0 live entries with max sequence as {s}..",
+                c = blocks.len(),
+                s = latest_sequence,
+            );
+            tracing::info!("[recover] finish in {:?}", elapsed);
+            metrics
+                .storage_block_engine_recover_duration
+                .record(elapsed.as_secs_f64());
+            return Ok(());
+        }
+
         // Recover blocks concurrently.
         let mode = recover_mode;
-        let total = stream::iter(blocks.into_iter().map(|id| {
+        let mut total = stream::iter(blocks.into_iter().enumerate().map(|(order, id)| {
             let block = block_manager.block(id).clone();
-            spawner.spawn(async move { BlockRecoverRunner::run(mode, block, blob_index_size).await })
+            spawner.spawn(async move { (order, BlockRecoverRunner::run(mode, block, blob_index_size).await) })
         }))
-        .buffered(recover_concurrency)
+        .buffer_unordered(recover_concurrency.max(1))
         .try_collect::<Vec<_>>()
         .await
         .unwrap();
+        // Preserve the original input order for error aggregation and equal-sequence replacement.
+        total.sort_unstable_by_key(|(order, _)| *order);
+        let total = total.into_iter().map(|(_, result)| result).collect::<Vec<_>>();
 
         // Return error is there is.
         let (total, errs): (Vec<_>, Vec<_>) = total.into_iter().partition(|res| res.is_ok());
@@ -81,40 +106,62 @@ impl RecoverRunner {
         // Install recovered entries into the indexer. The indexer deduplicates by sequence, so recovery does not need
         // an extra global dedup table.
         let mut latest_sequence = 0;
-        let mut clean_blocks = vec![];
-        let mut evictable_blocks = vec![];
-        let mut total_entries = 0;
+        let mut tombstone_sequences = HashMap::<u64, Sequence>::with_capacity(tombstones.len());
+        for tombstone in tombstones {
+            latest_sequence = latest_sequence.max(tombstone.sequence);
+            match tombstone_sequences.entry(tombstone.hash) {
+                Entry::Occupied(mut entry) => {
+                    *entry.get_mut() = (*entry.get()).max(tombstone.sequence);
+                }
+                Entry::Vacant(entry) => {
+                    entry.insert(tombstone.sequence);
+                }
+            }
+        }
 
-        for (block, infos) in total.into_iter().map(|r| r.unwrap()).enumerate() {
+        let mut clean_blocks = Vec::with_capacity(total.len());
+        let mut evictable_blocks = 0;
+        let total_entries = total.iter().map(|result| result.as_ref().unwrap().0.len()).sum();
+        let mut indices = Vec::with_capacity(total_entries);
+
+        for (block, (infos, block_latest_sequence)) in total.into_iter().map(|result| result.unwrap()).enumerate() {
             let block = block as BlockId;
-
             if infos.is_empty() {
                 clean_blocks.push(block);
             } else {
-                evictable_blocks.push(block);
+                evictable_blocks += 1;
             }
 
-            let indices = infos
-                .into_iter()
-                .map(|EntryInfo { hash, addr }| {
-                    latest_sequence = latest_sequence.max(addr.sequence);
-                    HashedEntryAddress { hash, address: addr }
-                })
-                .collect_vec();
-            total_entries += indices.len();
-            indexer.insert_batch(indices);
+            latest_sequence = latest_sequence.max(block_latest_sequence);
+            if tombstone_sequences.is_empty() {
+                indices.extend(
+                    infos
+                        .into_iter()
+                        .map(|EntryInfo { hash, addr }| HashedEntryAddress { hash, address: addr }),
+                );
+            } else {
+                indices.extend(infos.into_iter().filter_map(|EntryInfo { hash, addr }| {
+                    tombstone_sequences
+                        .get(&hash)
+                        .is_none_or(|sequence| addr.sequence > *sequence)
+                        .then_some(HashedEntryAddress { hash, address: addr })
+                }));
+            }
         }
-        tombstones.iter().for_each(|tombstone| {
-            latest_sequence = latest_sequence.max(tombstone.sequence);
-        });
-        indexer.remove_batch(tombstones.iter().map(|tombstone| (tombstone.hash, tombstone.sequence)));
+
+        indexer
+            .insert_recovery_batch(indices, recover_concurrency, spawner.clone())
+            .await
+            .unwrap();
+        let live_entries = indexer.compact_and_count();
 
         // Log recovery.
         tracing::info!(
-            "Recovers {e} blocks with data, {c} clean blocks, {t} total entries with max sequence as {s}..",
-            e = evictable_blocks.len(),
+            "Recovers {e} blocks with data, {c} clean blocks, {t} scanned entries, {l} live entries with max sequence as {s}..",
+            e = evictable_blocks,
             c = clean_blocks.len(),
             t = total_entries,
+            l = live_entries,
             s = latest_sequence,
         );
 
@@ -137,12 +184,13 @@ impl RecoverRunner {
 struct BlockRecoverRunner;
 
 impl BlockRecoverRunner {
-    async fn run(mode: RecoverMode, block: Block, blob_index_size: usize) -> Result<Vec<EntryInfo>> {
+    async fn run(mode: RecoverMode, block: Block, blob_index_size: usize) -> Result<(Vec<EntryInfo>, Sequence)> {
         if mode == RecoverMode::None {
-            return Ok(vec![]);
+            return Ok((vec![], 0));
         }
 
         let mut recovered = vec![];
+        let mut latest_sequence = 0;
 
         let id = block.id();
         let mut iter = BlockScanner::new(block, blob_index_size);
@@ -165,10 +213,105 @@ impl BlockRecoverRunner {
                 if info.addr.sequence < recovered.last().map(|last: &EntryInfo| last.addr.sequence).unwrap_or(0) {
                     break 'recover;
                 }
+                latest_sequence = latest_sequence.max(info.addr.sequence);
                 recovered.push(info);
             }
         }
 
-        Ok(recovered)
+        Ok((recovered, latest_sequence))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::sync::Arc;
+
+    use foyer_common::{metrics::Metrics, spawn::Spawner};
+    use tempfile::tempdir;
+
+    use super::BlockRecoverRunner;
+    use crate::{
+        Compression,
+        engine::{
+            RecoverMode,
+            block::{
+                buffer::{Buffer, SplitCtx, Splitter},
+                manager::Block,
+            },
+        },
+        io::{
+            bytes::IoSliceMut,
+            device::{DeviceBuilder, fs::FsDeviceBuilder},
+            engine::{IoEngineBuildContext, IoEngineConfig, psync::PsyncIoEngineConfig},
+        },
+    };
+
+    const KB: usize = 1024;
+
+    #[test_log::test(tokio::test)]
+    async fn test_block_recovery_stops_at_out_of_order_sequences() {
+        const BLOCK_SIZE: usize = 64 * KB;
+        const BLOB_INDEX_SIZE: usize = 4 * KB;
+
+        let dir = tempdir().unwrap();
+        let device = FsDeviceBuilder::new(dir.path())
+            .with_capacity(BLOCK_SIZE)
+            .build()
+            .unwrap();
+        let partition = device.create_partition(BLOCK_SIZE).unwrap();
+        let io_engine = PsyncIoEngineConfig::new()
+            .boxed()
+            .build(IoEngineBuildContext {
+                spawner: Spawner::current(),
+            })
+            .await
+            .unwrap();
+
+        let mut buffer = Buffer::new(
+            IoSliceMut::new(BLOCK_SIZE),
+            BLOCK_SIZE - BLOB_INDEX_SIZE,
+            Arc::new(Metrics::noop()),
+        );
+        for (key, sequence) in [2, 0, 1].into_iter().enumerate() {
+            assert!(buffer.push(
+                &(key as u64),
+                &vec![key as u8; 3 * KB],
+                key as u64,
+                Compression::None,
+                sequence,
+            ));
+        }
+
+        let (bytes, infos) = buffer.finish();
+        let mut split = SplitCtx::new(BLOCK_SIZE, BLOB_INDEX_SIZE);
+        let batch = Splitter::split(&mut split, bytes.into_io_slice(), infos);
+        assert_eq!(batch.blocks.len(), 1);
+        assert_eq!(batch.blocks[0].blob_parts.len(), 1);
+        let part = &batch.blocks[0].blob_parts[0];
+
+        let (_, result) = io_engine
+            .write(
+                Box::new(part.data.clone()),
+                partition.as_ref(),
+                part.blob_block_offset as u64 + part.part_blob_offset as u64,
+            )
+            .await;
+        result.unwrap();
+        let (_, result) = io_engine
+            .write(
+                Box::new(part.index.clone()),
+                partition.as_ref(),
+                part.blob_block_offset as u64,
+            )
+            .await;
+        result.unwrap();
+
+        let block = Block::new_for_test(0, partition, io_engine);
+        let (recovered, latest_sequence) = BlockRecoverRunner::run(RecoverMode::Strict, block, BLOB_INDEX_SIZE)
+            .await
+            .unwrap();
+        let sequences = recovered.into_iter().map(|info| info.addr.sequence).collect::<Vec<_>>();
+        assert_eq!(sequences, vec![2]);
+        assert_eq!(latest_sequence, 2);
     }
 }


### PR DESCRIPTION
## Summary

- Remove the recovery-local global `HashMap` and install recovered entries directly into the block indexer.
- Install entries in reusable, approximately 32 MiB batches; partition each batch once and update independent shards concurrently.
- Reduce allocation and hashing overhead with exact per-batch shard preallocation, `ModHasher`, tombstone prefiltering, and post-dedup compaction.
- Scan blocks with `buffer_unordered`, then restore their original order before error aggregation and index installation.
- Fast-path `RecoverMode::None` without scanning block contents.

## Semantics and Compatibility

This change is internal to recovery: it does not change the public API or the on-disk format.

The upstream recovery behavior is preserved:

- A block scan still stops at the first sequence regression.
- Results are restored to input-block order, so error selection and equal-sequence last-write-wins behavior remain deterministic, including across installation batches.
- Index replacement still uses the existing `sequence >= current.sequence()` rule.
- Tombstones still suppress entries at the same or an older sequence.
- Spawned-task panics still propagate through the existing `unwrap()` behavior.
- The global next sequence and clean-block initialization retain their previous meaning.

## Performance

Benchmarks used temporary local harnesses; no benchmark-only code is included in this PR.

### End-to-end recovery

Workload: 300,000 forced on-disk entries, 512-byte values, 30 reopens with `RecoverMode::Quiet`; the first reopen verifies representative keys.

| Comparison | Recover average | Result |
| --- | ---: | ---: |
| Original main snapshot (`9c24c8d`) | `33.652 ms` | baseline |
| Initial PR implementation (`f3c6f7b`) | `19.664 ms` | `1.71x` faster than that main snapshot |
| Previous PR head, follow-up run (`f3c6f7b`) | `19.609 ms` | follow-up baseline |
| Current semantics-preserving implementation | `~9.80 ms` | `~2.0x` faster than the previous PR head |

### 100M-entry scaling

The original synthetic index-installation benchmark plateaued at approximately `3.3 s` from concurrency 4 onward, showing that allocation, hash-table insertion, and memory bandwidth dominate beyond that point.

After adding bounded batching, a temporary 8-worker sanity run installed 100 million streamed unique entries in `1.41 s` (entry generation included; device scanning and final compaction excluded). This is not an apples-to-apples comparison with the original harness because the input-retention strategy differs; it is only a regression check for the new batching path.

## Memory and Tradeoffs

- Recovery still retains block scan results until all scan errors have been aggregated, preserving upstream error behavior.
- The additional flat and per-shard installation buffers are now bounded to approximately `64 MiB` in total instead of scaling with the entire recovered-entry set.
- The final index still scales with the number of unique live keys; a 100M-unique-key recovery therefore remains a multi-GiB workload.
- Parallel shard installation increases CPU and memory-bandwidth pressure and is bounded by `recover_concurrency`.
- The recovery-only insertion path discards replaced-address results because recovery has no consumer for them.
- Recovery logs distinguish `scanned entries` from compacted `live entries`.

## Review Follow-ups

- Shard selection uses mixed high bits before applying the shard mask/modulo, avoiding correlation with the low bits consumed by `ModHasher` inside each shard.
- Recovery logs explicitly report both scanned and live entry counts.
- Recovery installation is bounded and reuses its flat batch buffer, avoiding full-set duplication before deduplication.

## Validation

- `cargo fmt --all -- --check`
- `git diff --check`
- `cargo check -p foyer-storage --lib`
- `cargo test -p foyer-storage` — 24 passed
- `cargo clippy -p foyer-storage --all-targets -- -D warnings -A dead-code`
- Focused tests cover shard-bit distribution, duplicate-heavy compaction, and differential equivalence across recovery-batch boundaries, including equal-sequence replacement.
