### PR TITLE
docs: propose disk cache codec architecture

### DIFF
--- a/rfcs/disk-cache-codec.md
+++ b/rfcs/disk-cache-codec.md
@@ -3,6 +3,7 @@
 - Status: Draft
 - Scope: `foyer-common`, `foyer-storage`, and `foyer`
 - Target: A staged, backward-compatible refactor
+- Translation: [Simplified Chinese](disk-cache-codec.zh-CN.md)
 
 ## 1. Summary
 
@@ -72,6 +73,7 @@ The write path is already allocation-friendly: `EntrySerializer` writes directly
 - `Engine::load` returns a `'static` future and `Load::Entry` owns `K` and `V`. A result borrowing from the read buffer cannot safely escape.
 - A disk hit may be promoted into the memory cache. The result must remain valid independently of the load future.
 - `IoEngine::read` returns the submitted buffer, so its owner can be retained without changing the low-level psync or io_uring read model.
+- `bytes::Bytes::from_owner` preserves the owner's pointer without copying, but `Bytes` does not provide a type-level alignment guarantee. Slicing may shift the pointer by an arbitrary offset.
 - The current entry header is 36 bytes, and the value begins immediately after it. This does not provide sufficient payload alignment for general archived formats.
 - Compression runs before `Code::decode`; a view cannot point directly into compressed bytes.
 - Compression configuration appears at both the store and block-engine layers. The codec refactor should establish one owner for the transform pipeline and prevent configuration drift.
@@ -104,7 +106,8 @@ pub struct OwnedBytes {
 impl OwnedBytes {
     pub fn from_owner(owner: impl AsRef<[u8]> + Send + 'static) -> Self;
     pub fn slice(&self, range: impl RangeBounds<usize>) -> Self;
-    pub fn alignment(&self) -> usize;
+    pub fn address_alignment(&self) -> usize;
+    pub fn is_aligned_to(&self, alignment: usize) -> bool;
 }
 
 impl AsRef<[u8]> for OwnedBytes { /* ... */ }
@@ -112,7 +115,23 @@ impl AsRef<[u8]> for OwnedBytes { /* ... */ }
 
 The concrete implementation may use `bytes::Bytes::from_owner`. The owner is the buffer returned by `IoEngine::read`, not a copied `Vec<u8>`. Slices share the same owner and may begin at arbitrary byte offsets.
 
-`OwnedBytes` must not expose engine-specific buffer types. Its constructor and alignment calculation should remain internal to `foyer-storage` until the safety contract is stable.
+`OwnedBytes` must not expose engine-specific buffer types. Its constructor and alignment calculation should remain internal to `foyer-storage` until the safety contract is stable. `address_alignment` reports a property of the current slice pointer, not a stable guarantee of the `OwnedBytes` type. Every derived slice must be validated independently.
+
+The direct-I/O buffer and decode-view layers remain separate:
+
+```text
+Direct I/O submission:
+Raw / IoSliceMut / IoBuf
+  -> mutable when used for reads
+  -> pointer and length satisfy direct-I/O alignment
+
+After I/O completion:
+IoSliceMut -> IoSlice -> Bytes::from_owner -> OwnedBytes
+  -> immutable owner-backed view
+  -> arbitrary zero-copy payload slices
+```
+
+`Bytes` and `OwnedBytes` are not replacements for `IoBuf` or `IoBufMut`. Direct reads continue to use a mutable aligned buffer. An immutable `Bytes` value may be adapted for direct writes only after validating its pointer, length, and file offset; arbitrary `Bytes::slice` results must not be assumed to remain direct-I/O compatible. Converting an owner-backed `Bytes` into `BytesMut` performs a deep copy and is not a path back to the original mutable I/O allocation.
 
 ### 6.2 Value Codec
 
@@ -240,7 +259,7 @@ The new codec path requires a versioned entry envelope. The complete byte layout
 - Checksum algorithm and checksum.
 - Payload alignment, or enough information to validate it.
 
-The block-engine v2 layout should use an aligned payload start instead of placing the payload immediately after the current 36-byte header. A fixed 64-byte header is a reasonable initial option, but the implementation must derive offsets from codec-declared alignment rather than relying on a constant that happens to be aligned. Codec alignment must be a power of two and must not exceed I/O page alignment unless an engine explicitly advertises a stronger guarantee.
+The block-engine v2 layout should use an aligned payload start instead of placing the payload immediately after the current 36-byte header. A fixed 64-byte header is a reasonable initial option, but the implementation must derive offsets from codec-declared alignment rather than relying on a constant that happens to be aligned. Codec alignment must be a power of two and must not exceed I/O page alignment unless an engine explicitly advertises a stronger guarantee. Validation must use the actual payload slice pointer; a 4K-aligned backing allocation does not imply that every `Bytes` slice is aligned.
 
 Recovery behavior:
 
@@ -256,22 +275,26 @@ An engine supports the codec layer when it satisfies the following contract:
 
 1. It uses the configured codec for size estimation, encoding, and decoding.
 2. It encodes directly into an engine-owned destination or an equivalent bounded writer; pre-serializing every enqueue is not required.
-3. Its read result can be converted into `OwnedBytes` without copying.
-4. It honors `EntryLayoutRequirements`, or rejects the codec at build time with a capability error.
-5. It stores and validates codec format metadata in its entry envelope.
-6. It applies checksums and compression in the common order defined by this RFC.
+3. It submits a mutable buffer satisfying its direct-I/O pointer and length requirements, then converts the completed read result into `OwnedBytes` without copying.
+4. It does not treat arbitrary `OwnedBytes` or `Bytes` slices as direct-I/O-compatible buffers.
+5. It honors `EntryLayoutRequirements`, or rejects the codec at build time with a capability error.
+6. It stores and validates codec format metadata in its entry envelope.
+7. It applies checksums and compression in the common order defined by this RFC.
 
 Add explicit capabilities so that incompatibility is detected at build time:
 
 ```rust
 pub struct EngineCapabilities {
+    pub direct_io_alignment: usize,
     pub owner_backed_reads: bool,
     pub max_payload_alignment: usize,
     pub direct_encode: bool,
 }
 ```
 
-The current block engine, psync I/O engine, and io_uring I/O engine can satisfy owner-backed reads because completion returns the submitted buffer. `NoopEngine` trivially supports every codec because it never persists or decodes entries.
+`direct_io_alignment` describes the alignment required when submitting I/O. `max_payload_alignment` describes the strongest alignment the entry layout can provide to a codec payload. These are separate capabilities: preserving a 4K-aligned allocation does not make an arbitrary payload slice 4K-aligned.
+
+The current block engine, psync I/O engine, and io_uring I/O engine can satisfy owner-backed reads because completion returns the submitted buffer. Direct reads continue to use `IoSliceMut`; the returned owner is wrapped as `Bytes` only after completion. `NoopEngine` trivially supports every codec because it never persists or decodes entries.
 
 Future engines do not need serde-, bincode-, or archive-specific code. An engine that cannot retain a read buffer may still support owned codecs, but it must reject codecs that declare `requires_owner_backed_input`.
 
@@ -363,6 +386,7 @@ This stage validates ownership without changing the public codec API or disk for
 - Verify that the hash-collision path still compares the decoded key correctly.
 - Verify that the owner remains alive after `Engine::load` returns and after promotion into the memory cache.
 - Verify that cloned cache entries safely share the backing owner.
+- Verify that wrapping a full aligned I/O owner preserves its pointer and that an unaligned `Bytes` slice fails alignment validation.
 - Verify that every drop order releases the buffer exactly once.
 - Return typed errors without panicking for malformed offsets, lengths, alignments, checksums, and archive roots.
 - Recover legacy entries with `LegacyCodeCodec`.

--- a/rfcs/disk-cache-codec.md
+++ b/rfcs/disk-cache-codec.md
@@ -1,53 +1,53 @@
-# Disk Cache Codec 与 Zero-Copy Decode
+# Disk Cache Codec and Zero-Copy Decode
 
-- 状态：Draft
-- 范围：`foyer-common`、`foyer-storage`、`foyer`
-- 目标：分阶段、向后兼容地重构
+- Status: Draft
+- Scope: `foyer-common`, `foyer-storage`, and `foyer`
+- Target: A staged, backward-compatible refactor
 
-## 1. 摘要
+## 1. Summary
 
-本 RFC 建议将应用层 key/value codec 从 disk cache engine 中分离，并在同一套、与 engine 无关的契约上提供两条路径：
+This RFC proposes separating application-level key/value codecs from disk cache engines and providing two paths on top of the same engine-neutral contract:
 
-1. 面向普通 owned Rust 类型的默认路径。开启 `serde` feature 并派生 `Serialize`、`Deserialize` 后即可使用；同时提供显式的 `with_serde_codec` builder 快捷方法，使持久化格式在配置中可见。
-2. 面向性能敏感场景的高级路径。decoder 消费一段持有底层 owner 的 bytes，返回的 key/value 可以保留这段 bytes，并在其上暴露经过校验的视图，无需将字段复制出 I/O buffer。
-3. 所有 storage engine 共用一个 codec service。engine 仍负责 placement、batch、I/O、recovery 和 eviction，但不再自行决定应用类型如何编码。
+1. A default path for ordinary owned Rust types. Enabling the `serde` feature and deriving `Serialize` and `Deserialize` remains sufficient. An explicit `with_serde_codec` builder shortcut is also provided so that the persisted format is visible in configuration.
+2. An advanced path for performance-sensitive workloads. A decoder consumes an owner-backed byte range, and the returned key or value may retain that range and expose validated views over it without copying fields out of the I/O buffer.
+3. A common codec service shared by all storage engines. Engines remain responsible for placement, batching, I/O, recovery, and eviction, but no longer decide how application types are encoded.
 
-该方案与当前 I/O 模型兼容，因为读操作已经会归还 buffer 的所有权；它不要求让借用值逃逸出异步 `load` 调用。
+The proposal is feasible with the current I/O model because reads already return ownership of their buffers. It does not require a borrowed value to escape an asynchronous `load` call.
 
-## 2. 目标
+## 2. Goals
 
-- 保持简单场景足够简单：serde derive 加 Cargo feature 必须继续可用。
-- 允许每个 cache instance 显式选择 codec，而不是通过全局 feature 和 blanket impl 隐式决定格式。
-- 对支持 archived 或 byte-backed value 的格式，直接从 owned I/O buffer 解码。
-- 保留直接序列化到 engine write buffer 的能力，不在 enqueue 前强制预序列化。
-- 同一 codec 可用于 block engine 和未来的新 engine。
-- 在持久化 entry 中记录足够的格式标识，使 recovery 能确定性地拒绝不兼容数据。
-- 保持当前 `HybridCache<K, V, S>` 返回类型和 memory cache promotion 模型。
+- Keep the simple case simple: serde derives plus a Cargo feature must continue to work.
+- Allow each cache instance to select its codec explicitly instead of selecting one implicitly through global features and blanket implementations.
+- Decode directly from an owned I/O buffer for formats that support archived or byte-backed values.
+- Preserve direct serialization into an engine-owned write buffer; do not introduce mandatory pre-serialization before enqueue.
+- Make the same codec usable by the block engine and future engines.
+- Store enough format identity in persistent entries to reject incompatible data deterministically during recovery.
+- Preserve the current `HybridCache<K, V, S>` result type and memory-cache promotion model.
 
-## 3. 非目标
+## 3. Non-goals
 
-- 从 `load` 返回借用临时 future 的 `&K`、`&V` 或类似类型。
-- 让压缩读取完全无分配；解压必然需要另一段输出 buffer。
-- 要求所有 codec 都支持 zero-copy。
-- 让不同 storage engine 的完整磁盘布局互相兼容；codec identity 可复用，但 engine metadata 和 placement format 仍由 engine 管理。
-- 在第一阶段移除现有 `Code` API。
+- Returning `&K`, `&V`, or another value that borrows from a temporary load future.
+- Making compressed reads allocation-free. Decompression necessarily produces another byte buffer.
+- Requiring every codec to support zero-copy decode.
+- Making complete on-disk layouts portable across storage engines. Codec identity is reusable, but engine metadata and placement formats remain engine-owned.
+- Removing the existing `Code` API in the first stage.
 
-## 4. 当前实现
+## 4. Current State
 
-### 4.1 用户侧编码接口
+### 4.1 User-facing Coding API
 
-`foyer-common/src/code.rs` 定义了 `Code`、`StorageKey` 和 `StorageValue`：
+`foyer-common/src/code.rs` defines `Code`, `StorageKey`, and `StorageValue`:
 
-- `Code::encode` 写入 `std::io::Write`；
-- `Code::decode` 从 `std::io::Read` 读取并返回 owned `Self`；
-- `Code::estimated_size` 为 admission 和 buffer size 提供估算；
-- 开启 `serde` feature 后，所有 `Serialize + DeserializeOwned` 类型通过 blanket impl 使用 bincode。
+- `Code::encode` writes to `std::io::Write`.
+- `Code::decode` reads from `std::io::Read` and returns an owned `Self`.
+- `Code::estimated_size` supplies an estimate for admission and buffer sizing.
+- With the `serde` feature enabled, a blanket implementation uses bincode for every `Serialize + DeserializeOwned` type.
 
-因此，第一个需求实际上已经具备基础能力。当前限制是：格式由全局 feature 隐式选择，blanket impl 会通过 coherence 限制自定义实现，而 `Read` 无法把底层 buffer 的所有权转移给解码结果。
+The first requirement therefore already has a basic implementation. Its limitations are that the format is selected implicitly by a global feature, blanket implementations constrain custom implementations through coherence, and `Read` cannot transfer ownership of its backing buffer to the decoded value.
 
-### 4.2 Storage 数据流
+### 4.2 Storage Data Path
 
-当前 block engine 同时负责持久化和应用类型序列化：
+The block engine currently owns both persistence and application serialization:
 
 ```text
 Piece<K, V>
@@ -65,35 +65,35 @@ IoEngine::read
   -> optional promotion into the memory cache
 ```
 
-写路径已经比较高效：`EntrySerializer` 直接写入最终的 aligned block buffer，没有强制 staging allocation。读路径则会在构造 owned `K/V` 后丢弃 I/O buffer。
+The write path is already allocation-friendly: `EntrySerializer` writes directly into the final aligned block buffer without a mandatory staging allocation. The read path discards the I/O buffer after constructing owned `K` and `V` values.
 
-### 4.3 当前布局的关键约束
+### 4.3 Constraints in the Current Layout
 
-- `Engine::load` 返回 `'static` future，`Load::Entry` 持有 owned `K/V`，借用 read buffer 的结果无法安全逃逸。
-- disk hit 可能被 promotion 到 memory cache，所以结果必须脱离 load future 独立存活。
-- `IoEngine::read` 会归还调用方提交的 buffer，因此无需修改 psync 或 io_uring 的底层读模型即可保留 owner。
-- 当前 entry header 为 36 bytes，value 紧随其后，无法为通用 archived format 保证足够的 payload alignment。
-- compression 在 `Code::decode` 前执行，view 无法直接指向 compressed bytes。
-- compression 配置同时出现在 store 和 block-engine 层；codec 重构应确定唯一 owner，避免配置漂移。
+- `Engine::load` returns a `'static` future and `Load::Entry` owns `K` and `V`. A result borrowing from the read buffer cannot safely escape.
+- A disk hit may be promoted into the memory cache. The result must remain valid independently of the load future.
+- `IoEngine::read` returns the submitted buffer, so its owner can be retained without changing the low-level psync or io_uring read model.
+- The current entry header is 36 bytes, and the value begins immediately after it. This does not provide sufficient payload alignment for general archived formats.
+- Compression runs before `Code::decode`; a view cannot point directly into compressed bytes.
+- Compression configuration appears at both the store and block-engine layers. The codec refactor should establish one owner for the transform pipeline and prevent configuration drift.
 
-## 5. 核心决策
+## 5. Decision
 
-引入 owner-backed `OwnedBytes` 输入和 engine-neutral `EntryCodec<K, V>` service，同时保留 owned `Load<K, V, P>`。所谓 zero-copy value，是内部保留 `OwnedBytes` 的 owned value，而不是借用 load future 的 Rust reference。
+Introduce an owner-backed `OwnedBytes` input and an engine-neutral `EntryCodec<K, V>` service while preserving the owned `Load<K, V, P>` type. A zero-copy value is an owned value whose internal representation retains `OwnedBytes`; it is not a Rust reference borrowing from the load future.
 
-统一 transform pipeline：
+The unified transform pipeline is:
 
 ```text
 K/V -> codec encode -> optional compression -> checksum -> engine placement
 engine read -> checksum -> optional decompression -> codec decode -> K/V
 ```
 
-engine 负责物理 entry envelope 和 placement；codec 只负责应用 payload 格式。compression 和 checksum 位于应用 codec 之外，使所有 codec 共享一致的损坏检测、错误分类和 metrics。
+The engine owns the physical entry envelope and placement. The codec owns only the application payload format. Compression and checksums remain outside the application codec so that every codec shares consistent corruption handling, error classification, and metrics.
 
-## 6. API 草案
+## 6. Proposed API
 
-以下名称暂定，核心是 ownership 和分层契约。
+The names in this section are provisional. The important parts are the ownership and layering contracts.
 
-### 6.1 Owner-backed bytes
+### 6.1 Owner-backed Bytes
 
 ```rust
 #[derive(Clone)]
@@ -110,11 +110,11 @@ impl OwnedBytes {
 impl AsRef<[u8]> for OwnedBytes { /* ... */ }
 ```
 
-具体实现可使用 `bytes::Bytes::from_owner`。owner 是 `IoEngine::read` 返回的 buffer，而不是复制出来的 `Vec<u8>`；slice 共享同一 owner，并允许任意 byte offset。
+The concrete implementation may use `bytes::Bytes::from_owner`. The owner is the buffer returned by `IoEngine::read`, not a copied `Vec<u8>`. Slices share the same owner and may begin at arbitrary byte offsets.
 
-`OwnedBytes` 不应暴露 engine-specific buffer 类型。在 safety contract 稳定前，构造函数和 alignment 计算保持在 `foyer-storage` 内部。
+`OwnedBytes` must not expose engine-specific buffer types. Its constructor and alignment calculation should remain internal to `foyer-storage` until the safety contract is stable.
 
-### 6.2 Value codec
+### 6.2 Value Codec
 
 ```rust
 pub trait ValueCodec<T>: Send + Sync + Debug + 'static {
@@ -132,11 +132,11 @@ pub trait ValueCodec<T>: Send + Sync + Debug + 'static {
 }
 ```
 
-`decode` 消费 byte owner。普通 codec 反序列化出 owned `T` 后丢弃 `src`；zero-copy codec 则把 `src` 或其 slice 移入 `T`。
+`decode` consumes the byte owner. A normal codec deserializes an owned `T` and drops `src`; a zero-copy codec moves `src`, or one of its slices, into `T`.
 
-该 trait 保持 object-safe，使 builder 完成类型约束检查后可以 erase codec。`estimated_size` 返回 `Result`，避免 size error 被静默转换成零之类的错误行为。它只用于 admission 和 buffer reservation，不充当精确长度；实际长度由 bounded writer 统计。
+The trait is object-safe so that the selected codec can be erased after the builder checks its type bounds. `estimated_size` returns `Result` rather than silently converting a size error to zero. It is only an admission and reservation hint, not an exact length; a bounded writer tracks the actual encoded length.
 
-### 6.3 Entry codec service
+### 6.3 Entry Codec Service
 
 ```rust
 pub trait EntryCodec<K, V>: Send + Sync + Debug + 'static {
@@ -158,13 +158,13 @@ pub trait EntryCodec<K, V>: Send + Sync + Debug + 'static {
 }
 ```
 
-`PairCodec<KC, VC>` 组合两个 `ValueCodec`。独立的 entry-level trait 用于保证不同 engine 对 key/value framing、ordering 和 alignment 的处理一致。engine 根据 `layout` 先对齐 value start、调用 `encode_value`，再根据实际 value length 对齐 key start 并调用 `encode_key`；这样既保留 streaming compression 和 bounded direct write，也不会假设 size estimate 是精确值。
+`PairCodec<KC, VC>` composes two `ValueCodec` implementations. A separate entry-level trait keeps key/value framing, ordering, and alignment consistent across engines. The engine aligns the value start according to `layout`, calls `encode_value`, aligns the key start from the actual value length, and then calls `encode_key`. This preserves streaming compression and bounded direct writes without assuming that a size estimate is exact.
 
-codec service 通过 `EngineBuildContext<K, V>` 以 `Arc<dyn EntryCodec<K, V>>` 传给 engine。所有 engine 使用该 service，不再直接调用 `K::decode`、`V::decode` 或特定 serde library。
+The codec service is passed through `EngineBuildContext<K, V>` as `Arc<dyn EntryCodec<K, V>>`. Every engine uses this service instead of calling `K::decode`, `V::decode`, or a specific serialization library directly.
 
-### 6.4 简单 serde 路径
+### 6.4 Simple Serde Path
 
-第一阶段保留当前零额外配置行为：
+The first compatibility stage retains the current zero-additional-configuration behavior:
 
 ```toml
 [dependencies]
@@ -180,9 +180,9 @@ struct Value {
 }
 ```
 
-默认 `LegacyCodeCodec` 适配现有 `Code`，因此不要求 builder 调用。
+The default `LegacyCodeCodec` adapts the existing `Code` implementation, so no builder call is required.
 
-同时为新代码提供显式快捷方法：
+An explicit shortcut is also provided for new code:
 
 ```rust
 let cache = HybridCacheBuilder::new()
@@ -194,11 +194,11 @@ let cache = HybridCacheBuilder::new()
     .await?;
 ```
 
-对需要 recovery 的 cache，推荐显式形式，因为持久化格式由配置表达，而不再只是 Cargo feature 的隐式副作用。未来可以用独立 codec ID 增加其他 serde format，不会静默改变已有数据解释方式。
+The explicit form is recommended for recoverable caches because the persisted format becomes configuration rather than an implicit Cargo-feature side effect. Future serde formats can use distinct codec IDs without silently changing how existing data is interpreted.
 
-### 6.5 高级 zero-copy 路径
+### 6.5 Advanced Zero-Copy Path
 
-支持的模型是 owner-backed value。例如 bytes-oriented codec 返回包含 `OwnedBytes` 的 value；archived codec 返回包含 owner 和已校验 root offset 的 wrapper。
+The supported model is an owner-backed value. A bytes-oriented codec may return a value containing `OwnedBytes`; an archived codec may return a wrapper containing the owner and a validated root offset.
 
 ```rust
 pub struct ArchivedValue<T> {
@@ -212,9 +212,9 @@ impl<T> ArchivedValue<T> {
 }
 ```
 
-wrapper 不保存 self-referential Rust reference，而是保存 owner 和 offset，在访问时构造经过校验的 view。特定 archive library 所需的 `unsafe` 必须封装在小型、可独立审计的 adapter 中，不能散落到 engine。
+The wrapper must not store a self-referential Rust reference. It stores an owner and offsets, then constructs a validated view on access. Any `unsafe` required by a particular archive library belongs in a small, independently auditable adapter and must not be spread across engines.
 
-高级配置仍使用同一个 builder hook：
+Advanced configuration uses the same builder hook:
 
 ```rust
 let cache = HybridCacheBuilder::new()
@@ -226,42 +226,42 @@ let cache = HybridCacheBuilder::new()
     .await?;
 ```
 
-在未压缩读取中，device 填充 I/O buffer 后可以做到 payload decode zero-copy。该保证不等同于 kernel I/O zero-copy，也不承诺任意内存对象图的序列化不发生复制。
+For uncompressed reads, this provides zero-copy payload decode after the device fills the I/O buffer. It does not promise zero-copy kernel I/O or zero-copy serialization of an arbitrary in-memory object graph.
 
-## 7. 持久化 Entry Format
+## 7. Persistent Entry Format
 
-新 codec 路径需要 versioned entry envelope。完整 byte layout 仍可由 engine 决定，但 envelope 至少包含：
+The new codec path requires a versioned entry envelope. The complete byte layout remains engine-specific, but the envelope must contain at least:
 
-- entry magic 和 envelope version；
-- codec ID 和 codec version；
-- key offset 和 length；
-- value offset 和 length；
-- compression algorithm；
-- checksum algorithm 和 checksum；
-- payload alignment，或足以验证 alignment 的信息。
+- Entry magic and envelope version.
+- Codec ID and codec version.
+- Key offset and length.
+- Value offset and length.
+- Compression algorithm.
+- Checksum algorithm and checksum.
+- Payload alignment, or enough information to validate it.
 
-block-engine v2 layout 应使用 aligned payload start，不再把 payload 紧接在当前 36-byte header 后。固定 64-byte header 可以作为初始方案，但实现必须根据 codec 声明的 alignment 推导 offset，不能依赖常量碰巧对齐。codec alignment 必须是 2 的幂；除非 engine 显式承诺更强能力，否则不得超过 I/O page alignment。
+The block-engine v2 layout should use an aligned payload start instead of placing the payload immediately after the current 36-byte header. A fixed 64-byte header is a reasonable initial option, but the implementation must derive offsets from codec-declared alignment rather than relying on a constant that happens to be aligned. Codec alignment must be a power of two and must not exceed I/O page alignment unless an engine explicitly advertises a stronger guarantee.
 
-Recovery 行为：
+Recovery behavior:
 
-- envelope version 已知且 codec ID/version 匹配时才解码；
-- unknown codec 或 incompatible version 在 strict recovery 下属于配置错误；
-- quiet recovery 跳过不兼容 entry 并记录专用 metric，不能误报为 checksum corruption；
-- migration window 内通过 `LegacyCodeCodec` 继续读取 legacy envelope；
-- persistent cache 修改 codec 配置时，必须显式清空或执行迁移，绝不能用新格式解释旧 bytes。
+- Decode only when the envelope version is known and the codec ID and version match.
+- Treat an unknown codec or incompatible version as a configuration error in strict recovery mode.
+- In quiet recovery mode, skip incompatible entries and record a dedicated metric; do not report them as checksum corruption.
+- Keep the legacy envelope readable through `LegacyCodeCodec` during the migration window.
+- Changing the codec configuration of a persistent cache requires an explicit empty-cache policy or migration. New code must never reinterpret old bytes under a different format.
 
-## 8. Engine 兼容契约
+## 8. Engine Compatibility Contract
 
-一个 engine 支持 codec layer，需要满足：
+An engine supports the codec layer when it satisfies the following contract:
 
-1. 使用配置的 codec 完成 size estimation、encode 和 decode；
-2. 直接编码到 engine-owned destination 或等价的 bounded writer，不要求每次 enqueue 预序列化；
-3. read result 能无复制转换成 `OwnedBytes`；
-4. 遵守 `EntryLayoutRequirements`，否则在 build 阶段返回 capability error；
-5. 在 entry envelope 中存储并校验 codec format metadata；
-6. 按 RFC 规定的统一顺序应用 checksum 和 compression。
+1. It uses the configured codec for size estimation, encoding, and decoding.
+2. It encodes directly into an engine-owned destination or an equivalent bounded writer; pre-serializing every enqueue is not required.
+3. Its read result can be converted into `OwnedBytes` without copying.
+4. It honors `EntryLayoutRequirements`, or rejects the codec at build time with a capability error.
+5. It stores and validates codec format metadata in its entry envelope.
+6. It applies checksums and compression in the common order defined by this RFC.
 
-增加显式 capabilities，在 build 阶段发现不兼容：
+Add explicit capabilities so that incompatibility is detected at build time:
 
 ```rust
 pub struct EngineCapabilities {
@@ -271,25 +271,25 @@ pub struct EngineCapabilities {
 }
 ```
 
-当前 block engine、psync I/O engine 和 io_uring I/O engine 均可满足 owner-backed read，因为完成事件会归还提交的 buffer。`NoopEngine` 不持久化或解码数据，可视为支持所有 codec。
+The current block engine, psync I/O engine, and io_uring I/O engine can satisfy owner-backed reads because completion returns the submitted buffer. `NoopEngine` trivially supports every codec because it never persists or decodes entries.
 
-未来 engine 无需包含 serde、bincode 或 archive-specific 代码。无法保留 read buffer 的 engine 仍可支持 owned codec，但必须拒绝声明 `requires_owner_backed_input` 的 codec。
+Future engines do not need serde-, bincode-, or archive-specific code. An engine that cannot retain a read buffer may still support owned codecs, but it must reject codecs that declare `requires_owner_backed_input`.
 
-## 9. Compression 语义
+## 9. Compression Semantics
 
-必须精确定义 zero-copy capability：
+Zero-copy capability must be reported precisely:
 
-- `Compression::None`：解码结果可以保留原始 I/O buffer 的 slice；
-- compressed entry：解压到一段新的 aligned owner-backed buffer，codec 可以保留该 buffer 的 slice；这避免字段级复制，但不是 disk-buffer zero-copy；
-- 如果 codec 的格式或性能契约要求直接访问持久化 bytes，它可以拒绝 compression。
+- `Compression::None`: The decoded value may retain slices of the original I/O buffer.
+- Compressed entry: Decompression allocates a new aligned owner-backed buffer, and the codec may retain slices of that buffer. This avoids field-by-field copies but is not disk-buffer zero-copy.
+- A codec may reject compression when its format or performance contract requires direct access to persisted bytes.
 
-compression 应只在 store transform layer 配置一次，再传给 engine。迁移过程中，engine-specific compression knob 应删除或退化为内部 alias。
+Compression should be configured once at the store transform layer and then passed to engines. During migration, engine-specific compression knobs should be removed or reduced to internal aliases.
 
-## 10. Builder 与类型约束迁移
+## 10. Builder and Type-bound Migration
 
-当前 `StorageKey: Key + Code` 和 `StorageValue: Value + Code` 强制所有 disk-cache 类型经过 `Code`，即使用户提供了显式 codec。要获得干净的高级 API，必须放宽这些约束。
+The current `StorageKey: Key + Code` and `StorageValue: Value + Code` bounds force every disk-cache type through `Code`, even when the user provides an explicit codec. These bounds must be relaxed to provide a clean advanced API.
 
-只在 builder 上增加 codec type parameter，并在 build 后 erase：
+Add a codec type parameter only to the builder, and erase it after build:
 
 ```rust
 pub struct StorageBuilder<K, V, S, P, C = LegacyCodeCodec> {
@@ -298,145 +298,145 @@ pub struct StorageBuilder<K, V, S, P, C = LegacyCodeCodec> {
 }
 ```
 
-- 默认 builder 仅在 `K: StorageKey`、`V: StorageValue` 时提供 `build`，保持 source compatibility；
-- `with_codec` 改变 `C`，并在 build 时检查 `C: EntryCodec<K, V>`；
-- 构建结果仍为 `Store<K, V, S, P>` 和 `HybridCache<K, V, S>`，codec 以 erased service 保存；
-- engine 内部约束从 `StorageKey`/`StorageValue` 下沉为 `Key`/`Value` 加 codec service；
-- `Code`、`StorageKey`、`StorageValue` 保留为兼容接口，除非另有 deprecation RFC，否则不移除。
+- The default builder provides `build` only when `K: StorageKey` and `V: StorageValue`, preserving source compatibility.
+- `with_codec` changes `C` and checks `C: EntryCodec<K, V>` at build time.
+- The resulting types remain `Store<K, V, S, P>` and `HybridCache<K, V, S>`; the codec is stored as an erased service.
+- Internal engine bounds move from `StorageKey` and `StorageValue` to `Key` and `Value` plus the codec service.
+- `Code`, `StorageKey`, and `StorageValue` remain compatibility traits. They should not be removed without a separate deprecation RFC.
 
-这样 generic growth 只发生在 builder，不会给 cache handle 和用户侧 entry 增加 codec type parameter。
+This confines generic growth to the builder and avoids adding a codec type parameter to cache handles and user-facing entries.
 
-## 11. 实施计划
+## 11. Implementation Plan
 
-### Phase 0：建立基线和术语
+### Phase 0: Establish Baselines and Terminology
 
-- 为代表性的 owned value 增加 serialization/deserialization benchmark；
-- 记录 allocation count、copied bytes、decode latency 和 retained buffer memory；
-- 定义 codec mismatch、codec decode failure、zero-copy-capable read metrics；
-- 将当前 serde feature 行为记录为兼容基线。
+- Add serialization and deserialization benchmarks for representative owned values.
+- Record allocation count, copied bytes, decode latency, and retained buffer memory.
+- Define metrics for codec mismatch, codec decode failure, and zero-copy-capable reads.
+- Document the current serde-feature behavior as the compatibility baseline.
 
-### Phase 1：Owner-backed read buffer
+### Phase 1: Owner-backed Read Buffer
 
-- 在内部增加基于 `IoB` owner 的 `OwnedBytes`；
-- 解析 key/value range 前，先把 block read result 转成 shared owner；
-- 暂时通过兼容 adapter 继续调用 `Code::decode`，保持外部行为不变；
-- 增加 bounds、range、checksum、aliasing 和 drop-order 测试。
+- Add an internal `OwnedBytes` abstraction over returned `IoB` owners.
+- Convert the block read result into a shared owner before parsing key and value ranges.
+- Continue calling `Code::decode` through a compatibility adapter so that external behavior remains unchanged.
+- Add bounds, range, checksum, aliasing, and drop-order tests.
 
-此阶段只验证 ownership，不修改公开 codec API 和磁盘格式。
+This stage validates ownership without changing the public codec API or disk format.
 
-### Phase 2：Codec service 与 builder 集成
+### Phase 2: Codec Service and Builder Integration
 
-- 增加 `ValueCodec`、`EntryCodec`、`PairCodec` 和 `LegacyCodeCodec`；
-- 通过 generic `EngineBuildContext<K, V>` 传递 erased codec；
-- 将 size estimation、direct encode 和 decode 统一路由到 codec service；
-- 增加 `with_codec` 和 `with_serde_codec`；
-- 将 compression 的所有权集中到 transform layer；
-- 放宽内部类型约束，同时保留默认 `Code` build path。
+- Add `ValueCodec`, `EntryCodec`, `PairCodec`, and `LegacyCodeCodec`.
+- Pass the selected erased codec through a generic `EngineBuildContext<K, V>`.
+- Route size estimation, direct encoding, and decoding through the codec service.
+- Add `with_codec` and `with_serde_codec`.
+- Centralize compression ownership in the transform layer.
+- Relax internal type bounds while preserving the default `Code` build path.
 
-### Phase 3：Versioned、aligned envelope
+### Phase 3: Versioned and Aligned Envelope
 
-- 增加 block-engine v2 entry header 和 aligned key/value offset；
-- 持久化 codec ID/version 和 transform metadata；
-- 同时读取 legacy 和 v2 entry，显式配置 codec 时写 v2；
-- 为 unknown codec 增加 strict/quiet recovery 行为；
-- 提交 recovery fixture，以固定 bytes 测试未来 layout 兼容性。
+- Add the block-engine v2 entry header and aligned key/value offsets.
+- Persist codec ID, codec version, and transform metadata.
+- Read both legacy and v2 entries; write v2 for explicitly configured codecs.
+- Add strict and quiet recovery behavior for unknown codecs.
+- Commit recovery fixtures so future layout compatibility is tested against fixed bytes.
 
-### Phase 4：Zero-copy adapter
+### Phase 4: Zero-Copy Adapters
 
-- 先增加 bytes-backed codec 作为 reference implementation；
-- 审查 validation 和 MSRV 保证后，在可选 feature 下增加一个 archived-format adapter；
-- 所有 archive-specific `unsafe` 只存在于 adapter；
-- 暴露 engine capability validation 和明确的 build error；
-- 文档说明 memory retention：一个很小的 value 也可能保留 page-sized I/O allocation。
+- Add a bytes-backed codec as the reference implementation.
+- Add one archived-format adapter behind an optional feature after reviewing its validation and MSRV guarantees.
+- Keep all archive-specific `unsafe` inside the adapter.
+- Expose engine capability validation and actionable build errors.
+- Document memory-retention behavior: a small value may retain a page-sized I/O allocation.
 
-### Phase 5：稳定化
+### Phase 5: Stabilization
 
-- 对比 owned serde、manual `Code`、bytes-backed、archived uncompressed、archived compressed 路径；
-- 决定隐式 serde blanket impl 长期保留为默认还是在未来 major release 仅作为兼容层；
-- 至少让 block engine 和另一个 engine 共用同一 codec service 后，再稳定公开命名。
+- Compare owned serde, manual `Code`, bytes-backed, archived uncompressed, and archived compressed paths.
+- Decide whether the implicit serde blanket implementation remains the default or becomes compatibility-only in a future major release.
+- Stabilize public names only after the block engine and at least one additional engine use the same codec service.
 
-## 12. 验证计划
+## 12. Validation Plan
 
-### 正确性测试
+### Correctness Tests
 
-- serde value、manual `Code` value、byte-backed value 和 archived value round trip；
-- hash collision 路径仍正确比较 decoded key；
-- owner 在 `Engine::load` 返回后、promotion 到 memory cache 后仍存活；
-- cloned cache entry 安全共享 backing owner；
-- 任意 drop 顺序都只释放 buffer 一次；
-- 非法 offset、length、alignment、checksum 和 archive root 返回 typed error，不 panic；
-- `LegacyCodeCodec` 能 recovery legacy entry；
-- strict/quiet recovery 下，codec mismatch 与 corruption 正确区分；
-- 每个支持的 engine 通过同一套 codec conformance suite。
+- Round-trip serde values, manual `Code` values, byte-backed values, and archived values.
+- Verify that the hash-collision path still compares the decoded key correctly.
+- Verify that the owner remains alive after `Engine::load` returns and after promotion into the memory cache.
+- Verify that cloned cache entries safely share the backing owner.
+- Verify that every drop order releases the buffer exactly once.
+- Return typed errors without panicking for malformed offsets, lengths, alignments, checksums, and archive roots.
+- Recover legacy entries with `LegacyCodeCodec`.
+- Distinguish codec mismatch from corruption in strict and quiet recovery modes.
+- Run one common codec conformance suite against every supported engine.
 
-### Compression 测试
+### Compression Tests
 
-- uncompressed byte-backed decode 指向 read owner；
-- compressed decode 指向 decompression owner，而不是临时 compressed input；
-- 禁止 compression 的 codec 在 build 阶段失败。
+- Verify that uncompressed byte-backed decode points into the read owner.
+- Verify that compressed decode points into the decompression owner rather than the temporary compressed input.
+- Reject a codec that forbids compression at build time.
 
-### Benchmark
+### Benchmarks
 
-- 不同 payload size 的 serialization/deserialization throughput；
-- 每次 hit 的 allocation 和 copied bytes；
-- psync、io_uring 的 end-to-end hit latency；
-- archive validation 开销；
-- 每个 promoted value 的 retained memory，包括 page amplification；
-- legacy 和 v2 envelope 的 recovery throughput。
+- Serialization and deserialization throughput by payload size.
+- Allocations and copied bytes per hit.
+- End-to-end hit latency for psync and io_uring.
+- Archive-validation cost.
+- Retained memory per promoted value, including page amplification.
+- Recovery throughput with legacy and v2 envelopes.
 
-zero-copy 路径建议验收标准：
+Recommended acceptance criteria for the zero-copy path:
 
-- uncompressed engine read 完成后不再产生 payload-sized allocation；
-- returned I/O buffer 与 decoded value 之间不复制 payload bytes；
-- 现有 serde path 的性能回退不超过预先约定阈值；
-- 所有 engine conformance test 行为一致。
+- No payload-sized allocation after an uncompressed engine read.
+- No payload byte copy between the returned I/O buffer and the decoded value.
+- No regression beyond an agreed threshold on the existing serde path.
+- Identical behavior across the common engine conformance suite.
 
-## 13. 风险与缓解
+## 13. Risks and Mitigations
 
-### I/O memory 被长期保留
+### Retained I/O Memory
 
-小 value 可能保留整个 aligned read buffer。应尽量按 entry 精确读取，增加 retained-byte metric，并考虑为小于阈值的数据主动 copy。
+A small value may retain an entire aligned read buffer. Read exact entries where possible, expose retained-byte metrics, and consider copying values below a configurable threshold.
 
-### Archived access 中的 unsafe
+### Unsafe Archived Access
 
-alignment 不是充分条件，typed access 前还必须验证 bytes。validation 和 unsafe 应集中在独立 adapter，并单独 fuzz。
+Alignment alone is insufficient; bytes must also be validated before typed access. Centralize validation and unsafe code in a dedicated adapter and fuzz it independently.
 
-### 格式歧义
+### Format Ambiguity
 
-feature flag 不能静默改变已有持久化 bytes 的解释方式。必须持久化 codec identity，并显式处理 mismatch。
+Feature flags must not silently change how persisted bytes are interpreted. Persist codec identity and require explicit mismatch handling.
 
-### Dynamic dispatch 开销
+### Dynamic-dispatch Overhead
 
-每次 key/value encode 或 decode 只调用少数 codec 方法，正常 entry 中通常由序列化和 I/O 主导。应先测量，再考虑给长生命周期 cache type 增加 codec 泛型。
+Codec methods are called only a few times per key/value encode or decode, and serialization and I/O should dominate for normal entries. Measure the overhead before adding codec parameters to long-lived cache types.
 
-### “Zero-copy” 范围不清
+### Ambiguous “Zero-copy” Scope
 
-文档只承诺 buffer ownership transfer 和 view construction。compression、validation scratch space 或 engine limitation 需要分配时，不得宣传 allocation-free。
+Document the guarantee as buffer ownership transfer and view construction. Do not claim allocation-free behavior when compression, validation scratch space, or engine limitations require allocation.
 
-## 14. 备选方案
+## 14. Alternatives Considered
 
-### 从 `load` 返回 borrowed value
+### Return Borrowed Values from `load`
 
-不采用。它与 `'static` async future、object-safe engine dispatch、memory-cache promotion 和当前 owned `Load<K, V, P>` API 冲突。callback/lending API 会制造第二套访问模型，仍不能自然解决 promotion。
+Rejected. This conflicts with `'static` asynchronous futures, object-safe engine dispatch, memory-cache promotion, and the current owned `Load<K, V, P>` API. A callback or lending API would create a second access model without naturally solving promotion.
 
-### 每个 engine 自行选择 codec
+### Let Each Engine Select Its Own Codec
 
-不采用。这会重复应用序列化逻辑，使格式行为依赖 engine，也无法建立统一 conformance suite。
+Rejected. This duplicates application serialization logic, makes format behavior engine-dependent, and prevents a common conformance suite.
 
-### enqueue 前预序列化
+### Pre-serialize Before Enqueue
 
-不作为强制路径。它会给每次写入增加 allocation 和 memory pressure，并破坏当前 direct-to-block-buffer 行为。engine 应在自身 batching boundary 调用 codec service。
+Rejected as a mandatory path. It adds allocation and memory pressure to every write and breaks the current direct-to-block-buffer behavior. Engines should invoke the codec service at their natural batching boundaries.
 
-### 只增加 `Code::decode_from_bytes`
+### Add Only `Code::decode_from_bytes`
 
-可作为增量原型，但不适合作为最终抽象。它仍让格式由全局状态选择，保留 coherence conflict，也没有持久化 codec identity。Phase 1 可以使用内部等价接口验证 ownership，再引入完整 codec service。
+Useful as an incremental prototype, but insufficient as the final abstraction. It leaves format selection global, retains coherence conflicts, and does not persist codec identity. Phase 1 may use an internal equivalent to validate ownership before introducing the complete codec service.
 
-## 15. 待决问题
+## 15. Open Decisions
 
-- 选择第一个稳定的显式 serde format：兼容必须提供 bincode-v1 codec，新 cache 可以选择另一个独立 versioned format；
-- key/value codec 使用独立 alignment、format ID，还是由 `EntryCodec` 暴露组合 identity；
-- block engine 支持的最大 alignment 和 copy-below-size threshold；
-- 审查 validation guarantee、MSRV、维护状态和编译成本后，选择首个 archived-format integration；
-- quiet recovery 遇到 unknown-codec entry 时，是保留到未来兼容 reopen，还是立即 reclaim。
+- Select the first stable explicit serde format. Compatibility requires a bincode-v1 codec; new caches may select another independently versioned format.
+- Decide whether key and value codecs use separate alignments and format IDs or whether `EntryCodec` exposes one combined identity.
+- Set the maximum supported alignment and copy-below-size threshold for the block engine.
+- Select the first archived-format integration after reviewing validation guarantees, MSRV, maintenance status, and compile-time cost.
+- Decide whether quiet recovery retains unknown-codec entries for a later compatible reopen or reclaims them immediately.
 
-这些问题不阻塞 Phase 0 和 Phase 1，但在 v2 envelope 默认写入前必须确定。
+These decisions do not block Phases 0 and 1, but they must be resolved before the v2 envelope is written by default.

--- a/rfcs/disk-cache-codec.md
+++ b/rfcs/disk-cache-codec.md
@@ -1,0 +1,442 @@
+# Disk Cache Codec 与 Zero-Copy Decode
+
+- 状态：Draft
+- 范围：`foyer-common`、`foyer-storage`、`foyer`
+- 目标：分阶段、向后兼容地重构
+
+## 1. 摘要
+
+本 RFC 建议将应用层 key/value codec 从 disk cache engine 中分离，并在同一套、与 engine 无关的契约上提供两条路径：
+
+1. 面向普通 owned Rust 类型的默认路径。开启 `serde` feature 并派生 `Serialize`、`Deserialize` 后即可使用；同时提供显式的 `with_serde_codec` builder 快捷方法，使持久化格式在配置中可见。
+2. 面向性能敏感场景的高级路径。decoder 消费一段持有底层 owner 的 bytes，返回的 key/value 可以保留这段 bytes，并在其上暴露经过校验的视图，无需将字段复制出 I/O buffer。
+3. 所有 storage engine 共用一个 codec service。engine 仍负责 placement、batch、I/O、recovery 和 eviction，但不再自行决定应用类型如何编码。
+
+该方案与当前 I/O 模型兼容，因为读操作已经会归还 buffer 的所有权；它不要求让借用值逃逸出异步 `load` 调用。
+
+## 2. 目标
+
+- 保持简单场景足够简单：serde derive 加 Cargo feature 必须继续可用。
+- 允许每个 cache instance 显式选择 codec，而不是通过全局 feature 和 blanket impl 隐式决定格式。
+- 对支持 archived 或 byte-backed value 的格式，直接从 owned I/O buffer 解码。
+- 保留直接序列化到 engine write buffer 的能力，不在 enqueue 前强制预序列化。
+- 同一 codec 可用于 block engine 和未来的新 engine。
+- 在持久化 entry 中记录足够的格式标识，使 recovery 能确定性地拒绝不兼容数据。
+- 保持当前 `HybridCache<K, V, S>` 返回类型和 memory cache promotion 模型。
+
+## 3. 非目标
+
+- 从 `load` 返回借用临时 future 的 `&K`、`&V` 或类似类型。
+- 让压缩读取完全无分配；解压必然需要另一段输出 buffer。
+- 要求所有 codec 都支持 zero-copy。
+- 让不同 storage engine 的完整磁盘布局互相兼容；codec identity 可复用，但 engine metadata 和 placement format 仍由 engine 管理。
+- 在第一阶段移除现有 `Code` API。
+
+## 4. 当前实现
+
+### 4.1 用户侧编码接口
+
+`foyer-common/src/code.rs` 定义了 `Code`、`StorageKey` 和 `StorageValue`：
+
+- `Code::encode` 写入 `std::io::Write`；
+- `Code::decode` 从 `std::io::Read` 读取并返回 owned `Self`；
+- `Code::estimated_size` 为 admission 和 buffer size 提供估算；
+- 开启 `serde` feature 后，所有 `Serialize + DeserializeOwned` 类型通过 blanket impl 使用 bincode。
+
+因此，第一个需求实际上已经具备基础能力。当前限制是：格式由全局 feature 隐式选择，blanket impl 会通过 coherence 限制自定义实现，而 `Read` 无法把底层 buffer 的所有权转移给解码结果。
+
+### 4.2 Storage 数据流
+
+当前 block engine 同时负责持久化和应用类型序列化：
+
+```text
+Piece<K, V>
+  -> block flusher
+  -> EntrySerializer::serialize
+  -> aligned engine write buffer
+  -> IoEngine::write
+
+IoEngine::read
+  -> owned IoB
+  -> EntryHeader::read
+  -> EntryDeserializer::deserialize
+  -> owned (K, V)
+  -> Load::Entry
+  -> optional promotion into the memory cache
+```
+
+写路径已经比较高效：`EntrySerializer` 直接写入最终的 aligned block buffer，没有强制 staging allocation。读路径则会在构造 owned `K/V` 后丢弃 I/O buffer。
+
+### 4.3 当前布局的关键约束
+
+- `Engine::load` 返回 `'static` future，`Load::Entry` 持有 owned `K/V`，借用 read buffer 的结果无法安全逃逸。
+- disk hit 可能被 promotion 到 memory cache，所以结果必须脱离 load future 独立存活。
+- `IoEngine::read` 会归还调用方提交的 buffer，因此无需修改 psync 或 io_uring 的底层读模型即可保留 owner。
+- 当前 entry header 为 36 bytes，value 紧随其后，无法为通用 archived format 保证足够的 payload alignment。
+- compression 在 `Code::decode` 前执行，view 无法直接指向 compressed bytes。
+- compression 配置同时出现在 store 和 block-engine 层；codec 重构应确定唯一 owner，避免配置漂移。
+
+## 5. 核心决策
+
+引入 owner-backed `OwnedBytes` 输入和 engine-neutral `EntryCodec<K, V>` service，同时保留 owned `Load<K, V, P>`。所谓 zero-copy value，是内部保留 `OwnedBytes` 的 owned value，而不是借用 load future 的 Rust reference。
+
+统一 transform pipeline：
+
+```text
+K/V -> codec encode -> optional compression -> checksum -> engine placement
+engine read -> checksum -> optional decompression -> codec decode -> K/V
+```
+
+engine 负责物理 entry envelope 和 placement；codec 只负责应用 payload 格式。compression 和 checksum 位于应用 codec 之外，使所有 codec 共享一致的损坏检测、错误分类和 metrics。
+
+## 6. API 草案
+
+以下名称暂定，核心是 ownership 和分层契约。
+
+### 6.1 Owner-backed bytes
+
+```rust
+#[derive(Clone)]
+pub struct OwnedBytes {
+    inner: bytes::Bytes,
+}
+
+impl OwnedBytes {
+    pub fn from_owner(owner: impl AsRef<[u8]> + Send + 'static) -> Self;
+    pub fn slice(&self, range: impl RangeBounds<usize>) -> Self;
+    pub fn alignment(&self) -> usize;
+}
+
+impl AsRef<[u8]> for OwnedBytes { /* ... */ }
+```
+
+具体实现可使用 `bytes::Bytes::from_owner`。owner 是 `IoEngine::read` 返回的 buffer，而不是复制出来的 `Vec<u8>`；slice 共享同一 owner，并允许任意 byte offset。
+
+`OwnedBytes` 不应暴露 engine-specific buffer 类型。在 safety contract 稳定前，构造函数和 alignment 计算保持在 `foyer-storage` 内部。
+
+### 6.2 Value codec
+
+```rust
+pub trait ValueCodec<T>: Send + Sync + Debug + 'static {
+    fn format(&self) -> CodecFormat;
+
+    fn estimated_size(&self, value: &T) -> Result<usize>;
+
+    fn encode(&self, value: &T, dst: &mut dyn Write) -> Result<()>;
+
+    fn decode(&self, src: OwnedBytes) -> Result<T>;
+
+    fn required_alignment(&self) -> usize {
+        1
+    }
+}
+```
+
+`decode` 消费 byte owner。普通 codec 反序列化出 owned `T` 后丢弃 `src`；zero-copy codec 则把 `src` 或其 slice 移入 `T`。
+
+该 trait 保持 object-safe，使 builder 完成类型约束检查后可以 erase codec。`estimated_size` 返回 `Result`，避免 size error 被静默转换成零之类的错误行为。它只用于 admission 和 buffer reservation，不充当精确长度；实际长度由 bounded writer 统计。
+
+### 6.3 Entry codec service
+
+```rust
+pub trait EntryCodec<K, V>: Send + Sync + Debug + 'static {
+    fn format(&self) -> EntryCodecFormat;
+
+    fn estimated_size(&self, key: &K, value: &V) -> Result<usize>;
+
+    fn encode_key(&self, key: &K, dst: &mut dyn Write) -> Result<usize>;
+
+    fn encode_value(&self, value: &V, dst: &mut dyn Write) -> Result<usize>;
+
+    fn decode(
+        &self,
+        key: OwnedBytes,
+        value: OwnedBytes,
+    ) -> Result<(K, V)>;
+
+    fn layout(&self) -> EntryLayoutRequirements;
+}
+```
+
+`PairCodec<KC, VC>` 组合两个 `ValueCodec`。独立的 entry-level trait 用于保证不同 engine 对 key/value framing、ordering 和 alignment 的处理一致。engine 根据 `layout` 先对齐 value start、调用 `encode_value`，再根据实际 value length 对齐 key start 并调用 `encode_key`；这样既保留 streaming compression 和 bounded direct write，也不会假设 size estimate 是精确值。
+
+codec service 通过 `EngineBuildContext<K, V>` 以 `Arc<dyn EntryCodec<K, V>>` 传给 engine。所有 engine 使用该 service，不再直接调用 `K::decode`、`V::decode` 或特定 serde library。
+
+### 6.4 简单 serde 路径
+
+第一阶段保留当前零额外配置行为：
+
+```toml
+[dependencies]
+foyer = { version = "...", features = ["serde"] }
+serde = { version = "1", features = ["derive"] }
+```
+
+```rust
+#[derive(Clone, Debug, Eq, PartialEq, serde::Serialize, serde::Deserialize)]
+struct Value {
+    id: u64,
+    payload: String,
+}
+```
+
+默认 `LegacyCodeCodec` 适配现有 `Code`，因此不要求 builder 调用。
+
+同时为新代码提供显式快捷方法：
+
+```rust
+let cache = HybridCacheBuilder::new()
+    .memory(memory_capacity)
+    .storage()
+    .with_serde_codec(SerdeFormat::BincodeV1)
+    .with_engine_config(engine_config)
+    .build()
+    .await?;
+```
+
+对需要 recovery 的 cache，推荐显式形式，因为持久化格式由配置表达，而不再只是 Cargo feature 的隐式副作用。未来可以用独立 codec ID 增加其他 serde format，不会静默改变已有数据解释方式。
+
+### 6.5 高级 zero-copy 路径
+
+支持的模型是 owner-backed value。例如 bytes-oriented codec 返回包含 `OwnedBytes` 的 value；archived codec 返回包含 owner 和已校验 root offset 的 wrapper。
+
+```rust
+pub struct ArchivedValue<T> {
+    bytes: OwnedBytes,
+    root_offset: usize,
+    marker: PhantomData<T>,
+}
+
+impl<T> ArchivedValue<T> {
+    pub fn get(&self) -> &Archived<T>;
+}
+```
+
+wrapper 不保存 self-referential Rust reference，而是保存 owner 和 offset，在访问时构造经过校验的 view。特定 archive library 所需的 `unsafe` 必须封装在小型、可独立审计的 adapter 中，不能散落到 engine。
+
+高级配置仍使用同一个 builder hook：
+
+```rust
+let cache = HybridCacheBuilder::new()
+    .memory(memory_capacity)
+    .storage()
+    .with_codec(PairCodec::new(key_codec, archived_value_codec))
+    .with_engine_config(engine_config)
+    .build()
+    .await?;
+```
+
+在未压缩读取中，device 填充 I/O buffer 后可以做到 payload decode zero-copy。该保证不等同于 kernel I/O zero-copy，也不承诺任意内存对象图的序列化不发生复制。
+
+## 7. 持久化 Entry Format
+
+新 codec 路径需要 versioned entry envelope。完整 byte layout 仍可由 engine 决定，但 envelope 至少包含：
+
+- entry magic 和 envelope version；
+- codec ID 和 codec version；
+- key offset 和 length；
+- value offset 和 length；
+- compression algorithm；
+- checksum algorithm 和 checksum；
+- payload alignment，或足以验证 alignment 的信息。
+
+block-engine v2 layout 应使用 aligned payload start，不再把 payload 紧接在当前 36-byte header 后。固定 64-byte header 可以作为初始方案，但实现必须根据 codec 声明的 alignment 推导 offset，不能依赖常量碰巧对齐。codec alignment 必须是 2 的幂；除非 engine 显式承诺更强能力，否则不得超过 I/O page alignment。
+
+Recovery 行为：
+
+- envelope version 已知且 codec ID/version 匹配时才解码；
+- unknown codec 或 incompatible version 在 strict recovery 下属于配置错误；
+- quiet recovery 跳过不兼容 entry 并记录专用 metric，不能误报为 checksum corruption；
+- migration window 内通过 `LegacyCodeCodec` 继续读取 legacy envelope；
+- persistent cache 修改 codec 配置时，必须显式清空或执行迁移，绝不能用新格式解释旧 bytes。
+
+## 8. Engine 兼容契约
+
+一个 engine 支持 codec layer，需要满足：
+
+1. 使用配置的 codec 完成 size estimation、encode 和 decode；
+2. 直接编码到 engine-owned destination 或等价的 bounded writer，不要求每次 enqueue 预序列化；
+3. read result 能无复制转换成 `OwnedBytes`；
+4. 遵守 `EntryLayoutRequirements`，否则在 build 阶段返回 capability error；
+5. 在 entry envelope 中存储并校验 codec format metadata；
+6. 按 RFC 规定的统一顺序应用 checksum 和 compression。
+
+增加显式 capabilities，在 build 阶段发现不兼容：
+
+```rust
+pub struct EngineCapabilities {
+    pub owner_backed_reads: bool,
+    pub max_payload_alignment: usize,
+    pub direct_encode: bool,
+}
+```
+
+当前 block engine、psync I/O engine 和 io_uring I/O engine 均可满足 owner-backed read，因为完成事件会归还提交的 buffer。`NoopEngine` 不持久化或解码数据，可视为支持所有 codec。
+
+未来 engine 无需包含 serde、bincode 或 archive-specific 代码。无法保留 read buffer 的 engine 仍可支持 owned codec，但必须拒绝声明 `requires_owner_backed_input` 的 codec。
+
+## 9. Compression 语义
+
+必须精确定义 zero-copy capability：
+
+- `Compression::None`：解码结果可以保留原始 I/O buffer 的 slice；
+- compressed entry：解压到一段新的 aligned owner-backed buffer，codec 可以保留该 buffer 的 slice；这避免字段级复制，但不是 disk-buffer zero-copy；
+- 如果 codec 的格式或性能契约要求直接访问持久化 bytes，它可以拒绝 compression。
+
+compression 应只在 store transform layer 配置一次，再传给 engine。迁移过程中，engine-specific compression knob 应删除或退化为内部 alias。
+
+## 10. Builder 与类型约束迁移
+
+当前 `StorageKey: Key + Code` 和 `StorageValue: Value + Code` 强制所有 disk-cache 类型经过 `Code`，即使用户提供了显式 codec。要获得干净的高级 API，必须放宽这些约束。
+
+只在 builder 上增加 codec type parameter，并在 build 后 erase：
+
+```rust
+pub struct StorageBuilder<K, V, S, P, C = LegacyCodeCodec> {
+    codec: C,
+    marker: PhantomData<(K, V, S, P)>,
+}
+```
+
+- 默认 builder 仅在 `K: StorageKey`、`V: StorageValue` 时提供 `build`，保持 source compatibility；
+- `with_codec` 改变 `C`，并在 build 时检查 `C: EntryCodec<K, V>`；
+- 构建结果仍为 `Store<K, V, S, P>` 和 `HybridCache<K, V, S>`，codec 以 erased service 保存；
+- engine 内部约束从 `StorageKey`/`StorageValue` 下沉为 `Key`/`Value` 加 codec service；
+- `Code`、`StorageKey`、`StorageValue` 保留为兼容接口，除非另有 deprecation RFC，否则不移除。
+
+这样 generic growth 只发生在 builder，不会给 cache handle 和用户侧 entry 增加 codec type parameter。
+
+## 11. 实施计划
+
+### Phase 0：建立基线和术语
+
+- 为代表性的 owned value 增加 serialization/deserialization benchmark；
+- 记录 allocation count、copied bytes、decode latency 和 retained buffer memory；
+- 定义 codec mismatch、codec decode failure、zero-copy-capable read metrics；
+- 将当前 serde feature 行为记录为兼容基线。
+
+### Phase 1：Owner-backed read buffer
+
+- 在内部增加基于 `IoB` owner 的 `OwnedBytes`；
+- 解析 key/value range 前，先把 block read result 转成 shared owner；
+- 暂时通过兼容 adapter 继续调用 `Code::decode`，保持外部行为不变；
+- 增加 bounds、range、checksum、aliasing 和 drop-order 测试。
+
+此阶段只验证 ownership，不修改公开 codec API 和磁盘格式。
+
+### Phase 2：Codec service 与 builder 集成
+
+- 增加 `ValueCodec`、`EntryCodec`、`PairCodec` 和 `LegacyCodeCodec`；
+- 通过 generic `EngineBuildContext<K, V>` 传递 erased codec；
+- 将 size estimation、direct encode 和 decode 统一路由到 codec service；
+- 增加 `with_codec` 和 `with_serde_codec`；
+- 将 compression 的所有权集中到 transform layer；
+- 放宽内部类型约束，同时保留默认 `Code` build path。
+
+### Phase 3：Versioned、aligned envelope
+
+- 增加 block-engine v2 entry header 和 aligned key/value offset；
+- 持久化 codec ID/version 和 transform metadata；
+- 同时读取 legacy 和 v2 entry，显式配置 codec 时写 v2；
+- 为 unknown codec 增加 strict/quiet recovery 行为；
+- 提交 recovery fixture，以固定 bytes 测试未来 layout 兼容性。
+
+### Phase 4：Zero-copy adapter
+
+- 先增加 bytes-backed codec 作为 reference implementation；
+- 审查 validation 和 MSRV 保证后，在可选 feature 下增加一个 archived-format adapter；
+- 所有 archive-specific `unsafe` 只存在于 adapter；
+- 暴露 engine capability validation 和明确的 build error；
+- 文档说明 memory retention：一个很小的 value 也可能保留 page-sized I/O allocation。
+
+### Phase 5：稳定化
+
+- 对比 owned serde、manual `Code`、bytes-backed、archived uncompressed、archived compressed 路径；
+- 决定隐式 serde blanket impl 长期保留为默认还是在未来 major release 仅作为兼容层；
+- 至少让 block engine 和另一个 engine 共用同一 codec service 后，再稳定公开命名。
+
+## 12. 验证计划
+
+### 正确性测试
+
+- serde value、manual `Code` value、byte-backed value 和 archived value round trip；
+- hash collision 路径仍正确比较 decoded key；
+- owner 在 `Engine::load` 返回后、promotion 到 memory cache 后仍存活；
+- cloned cache entry 安全共享 backing owner；
+- 任意 drop 顺序都只释放 buffer 一次；
+- 非法 offset、length、alignment、checksum 和 archive root 返回 typed error，不 panic；
+- `LegacyCodeCodec` 能 recovery legacy entry；
+- strict/quiet recovery 下，codec mismatch 与 corruption 正确区分；
+- 每个支持的 engine 通过同一套 codec conformance suite。
+
+### Compression 测试
+
+- uncompressed byte-backed decode 指向 read owner；
+- compressed decode 指向 decompression owner，而不是临时 compressed input；
+- 禁止 compression 的 codec 在 build 阶段失败。
+
+### Benchmark
+
+- 不同 payload size 的 serialization/deserialization throughput；
+- 每次 hit 的 allocation 和 copied bytes；
+- psync、io_uring 的 end-to-end hit latency；
+- archive validation 开销；
+- 每个 promoted value 的 retained memory，包括 page amplification；
+- legacy 和 v2 envelope 的 recovery throughput。
+
+zero-copy 路径建议验收标准：
+
+- uncompressed engine read 完成后不再产生 payload-sized allocation；
+- returned I/O buffer 与 decoded value 之间不复制 payload bytes；
+- 现有 serde path 的性能回退不超过预先约定阈值；
+- 所有 engine conformance test 行为一致。
+
+## 13. 风险与缓解
+
+### I/O memory 被长期保留
+
+小 value 可能保留整个 aligned read buffer。应尽量按 entry 精确读取，增加 retained-byte metric，并考虑为小于阈值的数据主动 copy。
+
+### Archived access 中的 unsafe
+
+alignment 不是充分条件，typed access 前还必须验证 bytes。validation 和 unsafe 应集中在独立 adapter，并单独 fuzz。
+
+### 格式歧义
+
+feature flag 不能静默改变已有持久化 bytes 的解释方式。必须持久化 codec identity，并显式处理 mismatch。
+
+### Dynamic dispatch 开销
+
+每次 key/value encode 或 decode 只调用少数 codec 方法，正常 entry 中通常由序列化和 I/O 主导。应先测量，再考虑给长生命周期 cache type 增加 codec 泛型。
+
+### “Zero-copy” 范围不清
+
+文档只承诺 buffer ownership transfer 和 view construction。compression、validation scratch space 或 engine limitation 需要分配时，不得宣传 allocation-free。
+
+## 14. 备选方案
+
+### 从 `load` 返回 borrowed value
+
+不采用。它与 `'static` async future、object-safe engine dispatch、memory-cache promotion 和当前 owned `Load<K, V, P>` API 冲突。callback/lending API 会制造第二套访问模型，仍不能自然解决 promotion。
+
+### 每个 engine 自行选择 codec
+
+不采用。这会重复应用序列化逻辑，使格式行为依赖 engine，也无法建立统一 conformance suite。
+
+### enqueue 前预序列化
+
+不作为强制路径。它会给每次写入增加 allocation 和 memory pressure，并破坏当前 direct-to-block-buffer 行为。engine 应在自身 batching boundary 调用 codec service。
+
+### 只增加 `Code::decode_from_bytes`
+
+可作为增量原型，但不适合作为最终抽象。它仍让格式由全局状态选择，保留 coherence conflict，也没有持久化 codec identity。Phase 1 可以使用内部等价接口验证 ownership，再引入完整 codec service。
+
+## 15. 待决问题
+
+- 选择第一个稳定的显式 serde format：兼容必须提供 bincode-v1 codec，新 cache 可以选择另一个独立 versioned format；
+- key/value codec 使用独立 alignment、format ID，还是由 `EntryCodec` 暴露组合 identity；
+- block engine 支持的最大 alignment 和 copy-below-size threshold；
+- 审查 validation guarantee、MSRV、维护状态和编译成本后，选择首个 archived-format integration；
+- quiet recovery 遇到 unknown-codec entry 时，是保留到未来兼容 reopen，还是立即 reclaim。
+
+这些问题不阻塞 Phase 0 和 Phase 1，但在 v2 envelope 默认写入前必须确定。

--- a/rfcs/disk-cache-codec.zh-CN.md
+++ b/rfcs/disk-cache-codec.zh-CN.md
@@ -1,0 +1,466 @@
+# Disk Cache Codec 与 Zero-Copy Decode
+
+- 状态：Draft
+- 范围：`foyer-common`、`foyer-storage`、`foyer`
+- 目标：分阶段、向后兼容地重构
+- 原文：[English](disk-cache-codec.md)
+
+## 1. 摘要
+
+本 RFC 建议将应用层 key/value codec 从 disk cache engine 中分离，并在同一套、与 engine 无关的契约上提供两条路径：
+
+1. 面向普通 owned Rust 类型的默认路径。开启 `serde` feature 并派生 `Serialize`、`Deserialize` 后即可使用；同时提供显式的 `with_serde_codec` builder 快捷方法，使持久化格式在配置中可见。
+2. 面向性能敏感场景的高级路径。decoder 消费一段持有底层 owner 的 bytes，返回的 key/value 可以保留这段 bytes，并在其上暴露经过校验的视图，无需将字段复制出 I/O buffer。
+3. 所有 storage engine 共用一个 codec service。engine 仍负责 placement、batch、I/O、recovery 和 eviction，但不再自行决定应用类型如何编码。
+
+该方案与当前 I/O 模型兼容，因为读操作已经会归还 buffer 的所有权；它不要求让借用值逃逸出异步 `load` 调用。
+
+## 2. 目标
+
+- 保持简单场景足够简单：serde derive 加 Cargo feature 必须继续可用。
+- 允许每个 cache instance 显式选择 codec，而不是通过全局 feature 和 blanket impl 隐式决定格式。
+- 对支持 archived 或 byte-backed value 的格式，直接从 owned I/O buffer 解码。
+- 保留直接序列化到 engine write buffer 的能力，不在 enqueue 前强制预序列化。
+- 同一 codec 可用于 block engine 和未来的新 engine。
+- 在持久化 entry 中记录足够的格式标识，使 recovery 能确定性地拒绝不兼容数据。
+- 保持当前 `HybridCache<K, V, S>` 返回类型和 memory cache promotion 模型。
+
+## 3. 非目标
+
+- 从 `load` 返回借用临时 future 的 `&K`、`&V` 或类似类型。
+- 让压缩读取完全无分配；解压必然需要另一段输出 buffer。
+- 要求所有 codec 都支持 zero-copy。
+- 让不同 storage engine 的完整磁盘布局互相兼容；codec identity 可复用，但 engine metadata 和 placement format 仍由 engine 管理。
+- 在第一阶段移除现有 `Code` API。
+
+## 4. 当前实现
+
+### 4.1 用户侧编码接口
+
+`foyer-common/src/code.rs` 定义了 `Code`、`StorageKey` 和 `StorageValue`：
+
+- `Code::encode` 写入 `std::io::Write`；
+- `Code::decode` 从 `std::io::Read` 读取并返回 owned `Self`；
+- `Code::estimated_size` 为 admission 和 buffer size 提供估算；
+- 开启 `serde` feature 后，所有 `Serialize + DeserializeOwned` 类型通过 blanket impl 使用 bincode。
+
+因此，第一个需求实际上已经具备基础能力。当前限制是：格式由全局 feature 隐式选择，blanket impl 会通过 coherence 限制自定义实现，而 `Read` 无法把底层 buffer 的所有权转移给解码结果。
+
+### 4.2 Storage 数据流
+
+当前 block engine 同时负责持久化和应用类型序列化：
+
+```text
+Piece<K, V>
+  -> block flusher
+  -> EntrySerializer::serialize
+  -> aligned engine write buffer
+  -> IoEngine::write
+
+IoEngine::read
+  -> owned IoB
+  -> EntryHeader::read
+  -> EntryDeserializer::deserialize
+  -> owned (K, V)
+  -> Load::Entry
+  -> optional promotion into the memory cache
+```
+
+写路径已经比较高效：`EntrySerializer` 直接写入最终的 aligned block buffer，没有强制 staging allocation。读路径则会在构造 owned `K/V` 后丢弃 I/O buffer。
+
+### 4.3 当前布局的关键约束
+
+- `Engine::load` 返回 `'static` future，`Load::Entry` 持有 owned `K/V`，借用 read buffer 的结果无法安全逃逸。
+- disk hit 可能被 promotion 到 memory cache，所以结果必须脱离 load future 独立存活。
+- `IoEngine::read` 会归还调用方提交的 buffer，因此无需修改 psync 或 io_uring 的底层读模型即可保留 owner。
+- `bytes::Bytes::from_owner` 会无复制地保留 owner pointer，但 `Bytes` 不提供类型级 alignment 保证；slice 可以让 pointer 移动任意 offset。
+- 当前 entry header 为 36 bytes，value 紧随其后，无法为通用 archived format 保证足够的 payload alignment。
+- compression 在 `Code::decode` 前执行，view 无法直接指向 compressed bytes。
+- compression 配置同时出现在 store 和 block-engine 层；codec 重构应确定唯一 owner，避免配置漂移。
+
+## 5. 核心决策
+
+引入 owner-backed `OwnedBytes` 输入和 engine-neutral `EntryCodec<K, V>` service，同时保留 owned `Load<K, V, P>`。所谓 zero-copy value，是内部保留 `OwnedBytes` 的 owned value，而不是借用 load future 的 Rust reference。
+
+统一 transform pipeline：
+
+```text
+K/V -> codec encode -> optional compression -> checksum -> engine placement
+engine read -> checksum -> optional decompression -> codec decode -> K/V
+```
+
+engine 负责物理 entry envelope 和 placement；codec 只负责应用 payload 格式。compression 和 checksum 位于应用 codec 之外，使所有 codec 共享一致的损坏检测、错误分类和 metrics。
+
+## 6. API 草案
+
+以下名称暂定，核心是 ownership 和分层契约。
+
+### 6.1 Owner-backed bytes
+
+```rust
+#[derive(Clone)]
+pub struct OwnedBytes {
+    inner: bytes::Bytes,
+}
+
+impl OwnedBytes {
+    pub fn from_owner(owner: impl AsRef<[u8]> + Send + 'static) -> Self;
+    pub fn slice(&self, range: impl RangeBounds<usize>) -> Self;
+    pub fn address_alignment(&self) -> usize;
+    pub fn is_aligned_to(&self, alignment: usize) -> bool;
+}
+
+impl AsRef<[u8]> for OwnedBytes { /* ... */ }
+```
+
+具体实现可使用 `bytes::Bytes::from_owner`。owner 是 `IoEngine::read` 返回的 buffer，而不是复制出来的 `Vec<u8>`；slice 共享同一 owner，并允许任意 byte offset。
+
+`OwnedBytes` 不应暴露 engine-specific buffer 类型。在 safety contract 稳定前，构造函数和 alignment 计算保持在 `foyer-storage` 内部。`address_alignment` 描述当前 slice pointer 的属性，不是 `OwnedBytes` 类型的稳定保证；每个派生 slice 都必须独立校验。
+
+Direct I/O buffer 与 decode view 必须保持分层：
+
+```text
+Direct I/O submission:
+Raw / IoSliceMut / IoBuf
+  -> mutable when used for reads
+  -> pointer and length satisfy direct-I/O alignment
+
+After I/O completion:
+IoSliceMut -> IoSlice -> Bytes::from_owner -> OwnedBytes
+  -> immutable owner-backed view
+  -> arbitrary zero-copy payload slices
+```
+
+`Bytes` 和 `OwnedBytes` 不能替代 `IoBuf` 或 `IoBufMut`。Direct read 继续使用 mutable aligned buffer。只有校验 pointer、length 和 file offset 后，immutable `Bytes` 才能通过专用 adapter 用于 direct write；任意 `Bytes::slice` 结果不能被默认视为仍兼容 direct I/O。把 owner-backed `Bytes` 转换成 `BytesMut` 会执行 deep copy，不能借此恢复原始 mutable I/O allocation。
+
+### 6.2 Value codec
+
+```rust
+pub trait ValueCodec<T>: Send + Sync + Debug + 'static {
+    fn format(&self) -> CodecFormat;
+
+    fn estimated_size(&self, value: &T) -> Result<usize>;
+
+    fn encode(&self, value: &T, dst: &mut dyn Write) -> Result<()>;
+
+    fn decode(&self, src: OwnedBytes) -> Result<T>;
+
+    fn required_alignment(&self) -> usize {
+        1
+    }
+}
+```
+
+`decode` 消费 byte owner。普通 codec 反序列化出 owned `T` 后丢弃 `src`；zero-copy codec 则把 `src` 或其 slice 移入 `T`。
+
+该 trait 保持 object-safe，使 builder 完成类型约束检查后可以 erase codec。`estimated_size` 返回 `Result`，避免 size error 被静默转换成零之类的错误行为。它只用于 admission 和 buffer reservation，不充当精确长度；实际长度由 bounded writer 统计。
+
+### 6.3 Entry codec service
+
+```rust
+pub trait EntryCodec<K, V>: Send + Sync + Debug + 'static {
+    fn format(&self) -> EntryCodecFormat;
+
+    fn estimated_size(&self, key: &K, value: &V) -> Result<usize>;
+
+    fn encode_key(&self, key: &K, dst: &mut dyn Write) -> Result<usize>;
+
+    fn encode_value(&self, value: &V, dst: &mut dyn Write) -> Result<usize>;
+
+    fn decode(
+        &self,
+        key: OwnedBytes,
+        value: OwnedBytes,
+    ) -> Result<(K, V)>;
+
+    fn layout(&self) -> EntryLayoutRequirements;
+}
+```
+
+`PairCodec<KC, VC>` 组合两个 `ValueCodec`。独立的 entry-level trait 用于保证不同 engine 对 key/value framing、ordering 和 alignment 的处理一致。engine 根据 `layout` 先对齐 value start、调用 `encode_value`，再根据实际 value length 对齐 key start 并调用 `encode_key`；这样既保留 streaming compression 和 bounded direct write，也不会假设 size estimate 是精确值。
+
+codec service 通过 `EngineBuildContext<K, V>` 以 `Arc<dyn EntryCodec<K, V>>` 传给 engine。所有 engine 使用该 service，不再直接调用 `K::decode`、`V::decode` 或特定 serde library。
+
+### 6.4 简单 serde 路径
+
+第一阶段保留当前零额外配置行为：
+
+```toml
+[dependencies]
+foyer = { version = "...", features = ["serde"] }
+serde = { version = "1", features = ["derive"] }
+```
+
+```rust
+#[derive(Clone, Debug, Eq, PartialEq, serde::Serialize, serde::Deserialize)]
+struct Value {
+    id: u64,
+    payload: String,
+}
+```
+
+默认 `LegacyCodeCodec` 适配现有 `Code`，因此不要求 builder 调用。
+
+同时为新代码提供显式快捷方法：
+
+```rust
+let cache = HybridCacheBuilder::new()
+    .memory(memory_capacity)
+    .storage()
+    .with_serde_codec(SerdeFormat::BincodeV1)
+    .with_engine_config(engine_config)
+    .build()
+    .await?;
+```
+
+对需要 recovery 的 cache，推荐显式形式，因为持久化格式由配置表达，而不再只是 Cargo feature 的隐式副作用。未来可以用独立 codec ID 增加其他 serde format，不会静默改变已有数据解释方式。
+
+### 6.5 高级 zero-copy 路径
+
+支持的模型是 owner-backed value。例如 bytes-oriented codec 返回包含 `OwnedBytes` 的 value；archived codec 返回包含 owner 和已校验 root offset 的 wrapper。
+
+```rust
+pub struct ArchivedValue<T> {
+    bytes: OwnedBytes,
+    root_offset: usize,
+    marker: PhantomData<T>,
+}
+
+impl<T> ArchivedValue<T> {
+    pub fn get(&self) -> &Archived<T>;
+}
+```
+
+wrapper 不保存 self-referential Rust reference，而是保存 owner 和 offset，在访问时构造经过校验的 view。特定 archive library 所需的 `unsafe` 必须封装在小型、可独立审计的 adapter 中，不能散落到 engine。
+
+高级配置仍使用同一个 builder hook：
+
+```rust
+let cache = HybridCacheBuilder::new()
+    .memory(memory_capacity)
+    .storage()
+    .with_codec(PairCodec::new(key_codec, archived_value_codec))
+    .with_engine_config(engine_config)
+    .build()
+    .await?;
+```
+
+在未压缩读取中，device 填充 I/O buffer 后可以做到 payload decode zero-copy。该保证不等同于 kernel I/O zero-copy，也不承诺任意内存对象图的序列化不发生复制。
+
+## 7. 持久化 Entry Format
+
+新 codec 路径需要 versioned entry envelope。完整 byte layout 仍可由 engine 决定，但 envelope 至少包含：
+
+- entry magic 和 envelope version；
+- codec ID 和 codec version；
+- key offset 和 length；
+- value offset 和 length；
+- compression algorithm；
+- checksum algorithm 和 checksum；
+- payload alignment，或足以验证 alignment 的信息。
+
+block-engine v2 layout 应使用 aligned payload start，不再把 payload 紧接在当前 36-byte header 后。固定 64-byte header 可以作为初始方案，但实现必须根据 codec 声明的 alignment 推导 offset，不能依赖常量碰巧对齐。codec alignment 必须是 2 的幂；除非 engine 显式承诺更强能力，否则不得超过 I/O page alignment。校验必须使用实际 payload slice pointer；4K-aligned backing allocation 不代表每个 `Bytes` slice 都满足 alignment。
+
+Recovery 行为：
+
+- envelope version 已知且 codec ID/version 匹配时才解码；
+- unknown codec 或 incompatible version 在 strict recovery 下属于配置错误；
+- quiet recovery 跳过不兼容 entry 并记录专用 metric，不能误报为 checksum corruption；
+- migration window 内通过 `LegacyCodeCodec` 继续读取 legacy envelope；
+- persistent cache 修改 codec 配置时，必须显式清空或执行迁移，绝不能用新格式解释旧 bytes。
+
+## 8. Engine 兼容契约
+
+一个 engine 支持 codec layer，需要满足：
+
+1. 使用配置的 codec 完成 size estimation、encode 和 decode；
+2. 直接编码到 engine-owned destination 或等价的 bounded writer，不要求每次 enqueue 预序列化；
+3. 提交满足 direct-I/O pointer 和 length 约束的 mutable buffer，并在读取完成后无复制转换成 `OwnedBytes`；
+4. 不把任意 `OwnedBytes` 或 `Bytes` slice 当作 direct-I/O-compatible buffer；
+5. 遵守 `EntryLayoutRequirements`，否则在 build 阶段返回 capability error；
+6. 在 entry envelope 中存储并校验 codec format metadata；
+7. 按 RFC 规定的统一顺序应用 checksum 和 compression。
+
+增加显式 capabilities，在 build 阶段发现不兼容：
+
+```rust
+pub struct EngineCapabilities {
+    pub direct_io_alignment: usize,
+    pub owner_backed_reads: bool,
+    pub max_payload_alignment: usize,
+    pub direct_encode: bool,
+}
+```
+
+`direct_io_alignment` 描述提交 I/O 时的 alignment 要求；`max_payload_alignment` 描述 entry layout 能为 codec payload 提供的最大 alignment。两者是不同的 capability：保留 4K-aligned allocation 不会让任意 payload slice 自动满足 4K alignment。
+
+当前 block engine、psync I/O engine 和 io_uring I/O engine 均可满足 owner-backed read，因为完成事件会归还提交的 buffer。Direct read 继续使用 `IoSliceMut`，只在完成后才把返回的 owner 包装成 `Bytes`。`NoopEngine` 不持久化或解码数据，可视为支持所有 codec。
+
+未来 engine 无需包含 serde、bincode 或 archive-specific 代码。无法保留 read buffer 的 engine 仍可支持 owned codec，但必须拒绝声明 `requires_owner_backed_input` 的 codec。
+
+## 9. Compression 语义
+
+必须精确定义 zero-copy capability：
+
+- `Compression::None`：解码结果可以保留原始 I/O buffer 的 slice；
+- compressed entry：解压到一段新的 aligned owner-backed buffer，codec 可以保留该 buffer 的 slice；这避免字段级复制，但不是 disk-buffer zero-copy；
+- 如果 codec 的格式或性能契约要求直接访问持久化 bytes，它可以拒绝 compression。
+
+compression 应只在 store transform layer 配置一次，再传给 engine。迁移过程中，engine-specific compression knob 应删除或退化为内部 alias。
+
+## 10. Builder 与类型约束迁移
+
+当前 `StorageKey: Key + Code` 和 `StorageValue: Value + Code` 强制所有 disk-cache 类型经过 `Code`，即使用户提供了显式 codec。要获得干净的高级 API，必须放宽这些约束。
+
+只在 builder 上增加 codec type parameter，并在 build 后 erase：
+
+```rust
+pub struct StorageBuilder<K, V, S, P, C = LegacyCodeCodec> {
+    codec: C,
+    marker: PhantomData<(K, V, S, P)>,
+}
+```
+
+- 默认 builder 仅在 `K: StorageKey`、`V: StorageValue` 时提供 `build`，保持 source compatibility；
+- `with_codec` 改变 `C`，并在 build 时检查 `C: EntryCodec<K, V>`；
+- 构建结果仍为 `Store<K, V, S, P>` 和 `HybridCache<K, V, S>`，codec 以 erased service 保存；
+- engine 内部约束从 `StorageKey`/`StorageValue` 下沉为 `Key`/`Value` 加 codec service；
+- `Code`、`StorageKey`、`StorageValue` 保留为兼容接口，除非另有 deprecation RFC，否则不移除。
+
+这样 generic growth 只发生在 builder，不会给 cache handle 和用户侧 entry 增加 codec type parameter。
+
+## 11. 实施计划
+
+### Phase 0：建立基线和术语
+
+- 为代表性的 owned value 增加 serialization/deserialization benchmark；
+- 记录 allocation count、copied bytes、decode latency 和 retained buffer memory；
+- 定义 codec mismatch、codec decode failure、zero-copy-capable read metrics；
+- 将当前 serde feature 行为记录为兼容基线。
+
+### Phase 1：Owner-backed read buffer
+
+- 在内部增加基于 `IoB` owner 的 `OwnedBytes`；
+- 解析 key/value range 前，先把 block read result 转成 shared owner；
+- 暂时通过兼容 adapter 继续调用 `Code::decode`，保持外部行为不变；
+- 增加 bounds、range、checksum、aliasing 和 drop-order 测试。
+
+此阶段只验证 ownership，不修改公开 codec API 和磁盘格式。
+
+### Phase 2：Codec service 与 builder 集成
+
+- 增加 `ValueCodec`、`EntryCodec`、`PairCodec` 和 `LegacyCodeCodec`；
+- 通过 generic `EngineBuildContext<K, V>` 传递 erased codec；
+- 将 size estimation、direct encode 和 decode 统一路由到 codec service；
+- 增加 `with_codec` 和 `with_serde_codec`；
+- 将 compression 的所有权集中到 transform layer；
+- 放宽内部类型约束，同时保留默认 `Code` build path。
+
+### Phase 3：Versioned、aligned envelope
+
+- 增加 block-engine v2 entry header 和 aligned key/value offset；
+- 持久化 codec ID/version 和 transform metadata；
+- 同时读取 legacy 和 v2 entry，显式配置 codec 时写 v2；
+- 为 unknown codec 增加 strict/quiet recovery 行为；
+- 提交 recovery fixture，以固定 bytes 测试未来 layout 兼容性。
+
+### Phase 4：Zero-copy adapter
+
+- 先增加 bytes-backed codec 作为 reference implementation；
+- 审查 validation 和 MSRV 保证后，在可选 feature 下增加一个 archived-format adapter；
+- 所有 archive-specific `unsafe` 只存在于 adapter；
+- 暴露 engine capability validation 和明确的 build error；
+- 文档说明 memory retention：一个很小的 value 也可能保留 page-sized I/O allocation。
+
+### Phase 5：稳定化
+
+- 对比 owned serde、manual `Code`、bytes-backed、archived uncompressed、archived compressed 路径；
+- 决定隐式 serde blanket impl 长期保留为默认还是在未来 major release 仅作为兼容层；
+- 至少让 block engine 和另一个 engine 共用同一 codec service 后，再稳定公开命名。
+
+## 12. 验证计划
+
+### 正确性测试
+
+- serde value、manual `Code` value、byte-backed value 和 archived value round trip；
+- hash collision 路径仍正确比较 decoded key；
+- owner 在 `Engine::load` 返回后、promotion 到 memory cache 后仍存活；
+- cloned cache entry 安全共享 backing owner；
+- 将完整 aligned I/O owner 包装后 pointer 保持不变，而 unaligned `Bytes` slice 无法通过 alignment validation；
+- 任意 drop 顺序都只释放 buffer 一次；
+- 非法 offset、length、alignment、checksum 和 archive root 返回 typed error，不 panic；
+- `LegacyCodeCodec` 能 recovery legacy entry；
+- strict/quiet recovery 下，codec mismatch 与 corruption 正确区分；
+- 每个支持的 engine 通过同一套 codec conformance suite。
+
+### Compression 测试
+
+- uncompressed byte-backed decode 指向 read owner；
+- compressed decode 指向 decompression owner，而不是临时 compressed input；
+- 禁止 compression 的 codec 在 build 阶段失败。
+
+### Benchmark
+
+- 不同 payload size 的 serialization/deserialization throughput；
+- 每次 hit 的 allocation 和 copied bytes；
+- psync、io_uring 的 end-to-end hit latency；
+- archive validation 开销；
+- 每个 promoted value 的 retained memory，包括 page amplification；
+- legacy 和 v2 envelope 的 recovery throughput。
+
+zero-copy 路径建议验收标准：
+
+- uncompressed engine read 完成后不再产生 payload-sized allocation；
+- returned I/O buffer 与 decoded value 之间不复制 payload bytes；
+- 现有 serde path 的性能回退不超过预先约定阈值；
+- 所有 engine conformance test 行为一致。
+
+## 13. 风险与缓解
+
+### I/O memory 被长期保留
+
+小 value 可能保留整个 aligned read buffer。应尽量按 entry 精确读取，增加 retained-byte metric，并考虑为小于阈值的数据主动 copy。
+
+### Archived access 中的 unsafe
+
+alignment 不是充分条件，typed access 前还必须验证 bytes。validation 和 unsafe 应集中在独立 adapter，并单独 fuzz。
+
+### 格式歧义
+
+feature flag 不能静默改变已有持久化 bytes 的解释方式。必须持久化 codec identity，并显式处理 mismatch。
+
+### Dynamic dispatch 开销
+
+每次 key/value encode 或 decode 只调用少数 codec 方法，正常 entry 中通常由序列化和 I/O 主导。应先测量，再考虑给长生命周期 cache type 增加 codec 泛型。
+
+### “Zero-copy” 范围不清
+
+文档只承诺 buffer ownership transfer 和 view construction。compression、validation scratch space 或 engine limitation 需要分配时，不得宣传 allocation-free。
+
+## 14. 备选方案
+
+### 从 `load` 返回 borrowed value
+
+不采用。它与 `'static` async future、object-safe engine dispatch、memory-cache promotion 和当前 owned `Load<K, V, P>` API 冲突。callback/lending API 会制造第二套访问模型，仍不能自然解决 promotion。
+
+### 每个 engine 自行选择 codec
+
+不采用。这会重复应用序列化逻辑，使格式行为依赖 engine，也无法建立统一 conformance suite。
+
+### enqueue 前预序列化
+
+不作为强制路径。它会给每次写入增加 allocation 和 memory pressure，并破坏当前 direct-to-block-buffer 行为。engine 应在自身 batching boundary 调用 codec service。
+
+### 只增加 `Code::decode_from_bytes`
+
+可作为增量原型，但不适合作为最终抽象。它仍让格式由全局状态选择，保留 coherence conflict，也没有持久化 codec identity。Phase 1 可以使用内部等价接口验证 ownership，再引入完整 codec service。
+
+## 15. 待决问题
+
+- 选择第一个稳定的显式 serde format：兼容必须提供 bincode-v1 codec，新 cache 可以选择另一个独立 versioned format；
+- key/value codec 使用独立 alignment、format ID，还是由 `EntryCodec` 暴露组合 identity；
+- block engine 支持的最大 alignment 和 copy-below-size threshold；
+- 审查 validation guarantee、MSRV、维护状态和编译成本后，选择首个 archived-format integration；
+- quiet recovery 遇到 unknown-codec entry 时，是保留到未来兼容 reopen，还是立即 reclaim。
+
+这些问题不阻塞 Phase 0 和 Phase 1，但在 v2 envelope 默认写入前必须确定。


### PR DESCRIPTION
## What changed

- Added an English RFC for disk cache codecs and zero-copy decode, together with a Simplified Chinese translation.
- Designed a simple serde path, an owner-backed zero-copy path for advanced users, and an engine-neutral codec service.
- Clarified that `Raw`, `IoSliceMut`, and `IoBuf` remain the direct-I/O submission layer, while `Bytes` and `OwnedBytes` are immutable owner-backed decode views created after I/O completion.
- Distinguished direct-I/O alignment from payload alignment and required every derived byte slice to validate its actual pointer.
- Defined a versioned and aligned entry envelope, compression semantics, engine capabilities, validation criteria, and a five-stage implementation plan.

## Why

`Code::decode` currently constructs an owned value from `Read`, so it cannot transfer ownership of the I/O buffer to the decoded result. Serialization is also embedded directly in the block-engine data path. The RFC proposes `OwnedBytes` and `EntryCodec<K, V>` to separate application formats from storage engines while preserving the existing serde and `Code` compatibility path.

`Bytes::from_owner` can preserve a 4K-aligned allocation without copying, but `Bytes` does not provide a type-level alignment guarantee and arbitrary slices may shift the pointer. The RFC therefore keeps direct-I/O buffers and post-I/O decode views as separate abstractions.

## Impact

This PR adds documentation only. It does not change public APIs, persistent formats, or runtime behavior. Follow-up implementation work can proceed in the stages described by the RFC, with the remaining format decisions resolved before the v2 envelope becomes the default write format.

## Validation

- Confirmed that the PR scope contains only the two RFC documents.
- Checked both Markdown files for whitespace errors.
- Ran the repository typo checker against the English RFC.
- Scanned the English RFC for remaining CJK text.
- Verified that code blocks in the Chinese translation contain only English text.
- Reviewed the proposal against the current `Code`, `Engine`, block-engine, direct-I/O buffer, and I/O-buffer ownership data paths.