### PR TITLE
fix: reset memory usage on cache clear

### DIFF
--- a/foyer-memory/src/raw.rs
+++ b/foyer-memory/src/raw.rs
@@ -308,7 +308,11 @@ where
             garbages.push(record);
         }
 
+        let usage = std::mem::take(&mut self.usage);
         self.entries = 0;
+        if usage > 0 {
+            self.metrics.memory_usage.decrease(usage as _);
+        }
         if count > 0 {
             self.metrics.memory_entries.decrease(count);
             self.metrics.memory_remove.increase(count);
@@ -1657,6 +1661,28 @@ mod tests {
         pieces.sort_by_key(|t| t.0);
         let expected = (0..fifo.capacity() as u64).map(|i| (i, i, i)).collect_vec();
         assert_eq!(pieces, expected);
+    }
+
+    #[test]
+    fn test_clear_resets_usage() {
+        let fifo = fifo_cache_for_test();
+
+        for i in 0..4 {
+            fifo.insert(i, i);
+        }
+        assert_eq!(fifo.usage(), 4);
+        assert_eq!(fifo.entries(), 4);
+
+        fifo.clear();
+        assert_eq!(fifo.usage(), 0);
+        assert_eq!(fifo.entries(), 0);
+
+        // Clearing an empty cache must be idempotent, and accounting must remain
+        // correct when the cache is used again.
+        fifo.clear();
+        fifo.insert(4, 4);
+        assert_eq!(fifo.usage(), 1);
+        assert_eq!(fifo.entries(), 1);
     }
 
     #[test]


### PR DESCRIPTION
## Summary

  `RawCache::clear()` removed all cached entries but did not reset the per-shard memory usage. This left `usage()` and the memory usage metric with stale values and affected accounting after the cache was reused.

  This PR resets the usage during cache clearing and updates the corresponding metric. It also adds a regression test covering normal clear, repeated clear, and insertion after clear.
  
ref: #973