### PR TITLE
fix(storage): skip obsolete block cache reinsertions

### DIFF
--- a/foyer-common/src/metrics.rs
+++ b/foyer-common/src/metrics.rs
@@ -76,6 +76,8 @@ pub struct Metrics {
 
     pub storage_block_engine_indexer_conflict: BoxedCounter,
     pub storage_block_engine_enqueue_skip: BoxedCounter,
+    pub storage_block_engine_reinsert: BoxedCounter,
+    pub storage_block_engine_reinsert_skip_obsolete: BoxedCounter,
     pub storage_block_engine_buffer_efficiency: BoxedHistogram,
     pub storage_block_engine_recover_duration: BoxedHistogram,
 
@@ -279,6 +281,10 @@ impl Metrics {
             foyer_storage_block_engine_op_total.counter(&[name.clone(), "indexer_conflict".into()]);
         let storage_block_engine_enqueue_skip =
             foyer_storage_block_engine_op_total.counter(&[name.clone(), "enqueue_skip".into()]);
+        let storage_block_engine_reinsert =
+            foyer_storage_block_engine_op_total.counter(&[name.clone(), "reinsert".into()]);
+        let storage_block_engine_reinsert_skip_obsolete =
+            foyer_storage_block_engine_op_total.counter(&[name.clone(), "reinsert_skip_obsolete".into()]);
         let storage_block_engine_buffer_efficiency =
             foyer_storage_block_engine_buffer_efficiency.histogram(std::slice::from_ref(&name));
         let storage_block_engine_recover_duration =
@@ -358,6 +364,8 @@ impl Metrics {
             storage_entry_deserialize_duration,
             storage_block_engine_indexer_conflict,
             storage_block_engine_enqueue_skip,
+            storage_block_engine_reinsert,
+            storage_block_engine_reinsert_skip_obsolete,
             storage_block_engine_buffer_efficiency,
             storage_block_engine_recover_duration,
 

--- a/foyer-storage/src/engine/block/flusher.rs
+++ b/foyer-storage/src/engine/block/flusher.rs
@@ -62,6 +62,10 @@ use crate::{
     keeper::PieceRef,
 };
 
+fn is_current_reinsertion(indexer: &Indexer, hash: u64, source: &EntryAddress) -> bool {
+    indexer.get(hash).as_ref() == Some(source)
+}
+
 pub enum Submission<K, V, P>
 where
     K: StorageKey,
@@ -445,13 +449,22 @@ where
 
             Submission::Tombstone { tombstone, stats } => self.tombstone_infos.push(TombstoneInfo { tombstone, stats }),
             Submission::Reinsertion { reinsertion } => {
-                // Skip reinsertion if the entry is not in the indexer.
-                if self.indexer.get(reinsertion.hash).is_some() {
-                    report(self.buffer.as_mut().unwrap().push_slice(
-                        &reinsertion.slice[..reinsertion.len],
+                // Only reinsert if the index still points to the physical entry being reclaimed.
+                // A disk hit can be promoted to memory and then evicted back with a newer sequence
+                // while the old disk region is being scanned. Hash existence alone would let that
+                // obsolete physical copy consume another disk write before the sequence check.
+                if is_current_reinsertion(&self.indexer, reinsertion.hash, &reinsertion.source) {
+                    let enqueued = self.buffer.as_mut().unwrap().push_slice(
+                        &reinsertion.slice[..reinsertion.source.len as usize],
                         reinsertion.hash,
-                        reinsertion.sequence,
-                    ));
+                        reinsertion.source.sequence,
+                    );
+                    if enqueued {
+                        self.metrics.storage_block_engine_reinsert.increase(1);
+                    }
+                    report(enqueued);
+                } else {
+                    self.metrics.storage_block_engine_reinsert_skip_obsolete.increase(1);
                 }
             }
             Submission::Wait { tx } => self.waiters.push(tx),
@@ -678,5 +691,49 @@ where
         self.metrics
             .storage_queue_rotate_duration
             .record(init.elapsed().as_secs_f64());
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_reinsertion_requires_exact_source_address() {
+        let indexer = Indexer::new(1);
+        let hash = 7;
+        let source = EntryAddress {
+            block: 1,
+            offset: 4096,
+            len: 4096,
+            sequence: 1,
+        };
+        indexer.insert_batch(vec![HashedEntryAddress {
+            hash,
+            address: source.clone(),
+        }]);
+        assert!(is_current_reinsertion(&indexer, hash, &source));
+
+        indexer.insert_batch(vec![HashedEntryAddress {
+            hash,
+            address: EntryAddress {
+                block: 2,
+                offset: 8192,
+                len: 4096,
+                sequence: 1,
+            },
+        }]);
+        assert!(!is_current_reinsertion(&indexer, hash, &source));
+
+        indexer.insert_batch(vec![HashedEntryAddress {
+            hash,
+            address: EntryAddress {
+                block: 3,
+                offset: 12288,
+                len: 4096,
+                sequence: 2,
+            },
+        }]);
+        assert!(!is_current_reinsertion(&indexer, hash, &source));
     }
 }

--- a/foyer-storage/src/engine/block/reclaimer.rs
+++ b/foyer-storage/src/engine/block/reclaimer.rs
@@ -29,10 +29,9 @@ use crate::{
     Statistics, StorageFilter,
     engine::block::{
         flusher::{Flusher, Submission},
-        indexer::Indexer,
+        indexer::{EntryAddress, Indexer},
         manager::{Block, ReclaimingBlock},
         scanner::BlockScanner,
-        serde::Sequence,
     },
     io::{
         PAGE,
@@ -151,8 +150,7 @@ where
                         flusher.submit(Submission::Reinsertion {
                             reinsertion: Reinsertion {
                                 hash: info.hash,
-                                len: info.addr.len as usize,
-                                sequence: info.addr.sequence,
+                                source: info.addr,
                                 slice,
                             },
                         });
@@ -202,7 +200,6 @@ impl BlockCleaner {
 #[derive(Debug)]
 pub struct Reinsertion {
     pub hash: u64,
-    pub len: usize,
-    pub sequence: Sequence,
+    pub source: EntryAddress,
     pub slice: IoSlice,
 }


### PR DESCRIPTION
## What's changed and what's your intention?

During block reclamation, a reinsertion candidate is read from a physical entry address and queued for a flusher. Before the flusher consumes it, the same hash can be updated to a newer physical entry. The old code only checked whether the hash still existed in the indexer, so it could enqueue the obsolete payload again and cause redundant disk writes.

This PR:

- carries the source `EntryAddress` with each reinsertion request;
- reinserts only when the indexer still points to that exact physical address;
- records successful reinsertions and obsolete-address skips in the existing block-engine operation metrics;
- adds a regression test covering same-hash updates to a different address or sequence.

The sequence check during index updates still protects the logical cache entry. This change avoids the unnecessary physical reinsertion work earlier in the pipeline.

## Checklist

- [x] I have written the necessary rustdoc comments, or no new public API requires them.
- [x] I have added the necessary unit tests and integration tests.
- [ ] I have passed `cargo x` (or `cargo x --fast` instead if the old tests are not modified) in my local environment.

Local validation completed:

- `cargo +1.93.0 test -p foyer-storage test_reinsertion_requires_exact_source_address`
- `cargo clippy --all-targets` through `cargo x --fast`
- `cargo nextest run --all --features strict_assertions`: 102 passed
- `cargo test --doc`: passed
- nightly docs with `nightly-2026-06-11`: passed
- all examples and `cargo machete`: passed

`cargo x --fast` could not complete its final license step because `license-eye` v0.7.0 panics when the repository is a linked Git worktree. No license headers are changed by this PR.

## Related issues or PRs (optional)

None.
