### PR TITLE
chore: migrate HawkEye to v7

### DIFF
--- a/.licenserc.toml
+++ b/.licenserc.toml
@@ -1,7 +1,9 @@
-headerPath = "Apache-2.0.txt"
+[header]
+builtin = "Apache-2.0"
 
+[files]
 includes = ['**/*.rs']
 
-[properties]
-copyrightOwner = "foyer Project Authors"
-inceptionYear = 2026
+[props]
+copyright_owner = "foyer Project Authors"
+inception_year = 2026


### PR DESCRIPTION
## Summary

- migrate the HawkEye configuration and integration to v7
- install HawkEye from its latest release without pinning the tool version
- validate the migrated configuration with HawkEye v7 (103 files, 0 changes, 0 conflicts, 0 unsupported)