### PR TITLE
feat: support selective hybrid cache flushing

### DIFF
--- a/foyer-memory/src/cache.rs
+++ b/foyer-memory/src/cache.rs
@@ -909,6 +909,26 @@ where
         }
     }
 
+    /// Evict entries matching the predicate and offload them into the disk cache via the pipe if needed.
+    ///
+    /// This function obeys the io throttler of the disk cache and makes sure all matching entries are offloaded.
+    /// Therefore, this function is asynchronous.
+    ///
+    /// The predicate is called while holding a shard lock and must not access this cache.
+    #[cfg_attr(feature = "tracing", fastrace::trace(name = "foyer::memory::cache::flush_if"))]
+    pub async fn flush_if<F>(&self, predicate: F)
+    where
+        F: FnMut(&K, &V) -> bool,
+    {
+        match self {
+            Cache::Fifo(cache) => cache.flush_if(predicate).await,
+            Cache::S3Fifo(cache) => cache.flush_if(predicate).await,
+            Cache::Lru(cache) => cache.flush_if(predicate).await,
+            Cache::Lfu(cache) => cache.flush_if(predicate).await,
+            Cache::Sieve(cache) => cache.flush_if(predicate).await,
+        }
+    }
+
     /// Return a new hybrid cache with the given pipe.
     #[doc(hidden)]
     pub fn with_pipe(self, pipe: ArcPipe<K, V, P>) -> Self {

--- a/foyer-memory/src/indexer/hash_table.rs
+++ b/foyer-memory/src/indexer/hash_table.rs
@@ -40,6 +40,18 @@ where
     }
 }
 
+impl<E> HashTableIndexer<E>
+where
+    E: Eviction,
+{
+    pub(crate) fn extract_if<'a, F>(&'a mut self, mut predicate: F) -> impl Iterator<Item = Arc<Record<E>>> + 'a
+    where
+        F: FnMut(&Arc<Record<E>>) -> bool + 'a,
+    {
+        self.table.extract_if(move |record| predicate(record))
+    }
+}
+
 impl<E> Indexer for HashTableIndexer<E>
 where
     E: Eviction,

--- a/foyer-memory/src/indexer/sentry.rs
+++ b/foyer-memory/src/indexer/sentry.rs
@@ -18,7 +18,7 @@ use equivalent::Equivalent;
 use foyer_common::strict_assert;
 
 use super::Indexer;
-use crate::{eviction::Eviction, record::Record};
+use crate::{eviction::Eviction, indexer::hash_table::HashTableIndexer, record::Record};
 
 /// [`Sentry`] is a guard for all [`Indexer`] implementations to set `IN_INDEXER` flag properly.
 pub struct Sentry<I>
@@ -34,6 +34,21 @@ where
 {
     fn default() -> Self {
         Self { indexer: I::default() }
+    }
+}
+
+impl<E> Sentry<HashTableIndexer<E>>
+where
+    E: Eviction,
+{
+    pub(crate) fn extract_if<'a, F>(&'a mut self, predicate: F) -> impl Iterator<Item = Arc<Record<E>>> + 'a
+    where
+        F: FnMut(&Arc<Record<E>>) -> bool + 'a,
+    {
+        self.indexer.extract_if(predicate).inspect(|record| {
+            strict_assert!(record.is_in_indexer());
+            record.set_in_indexer(false);
+        })
     }
 }
 

--- a/foyer-memory/src/raw.rs
+++ b/foyer-memory/src/raw.rs
@@ -696,10 +696,10 @@ where
             shard.write().evict(0, &mut garbages);
         }
 
-        self.flush_garbages(garbages).await;
+        self.flush_evicted(garbages).await;
     }
 
-    async fn flush_garbages(&self, garbages: Vec<(Event, Arc<Record<E>>)>) {
+    async fn flush_evicted(&self, garbages: Vec<(Event, Arc<Record<E>>)>) {
         // Deallocate data out of the lock critical section.
         let piped = self.pipe.is_enabled();
 
@@ -861,7 +861,7 @@ where
         }
 
         drop(predicate);
-        self.flush_garbages(garbages).await;
+        self.flush_evicted(garbages).await;
     }
 }
 

--- a/foyer-memory/src/raw.rs
+++ b/foyer-memory/src/raw.rs
@@ -45,7 +45,7 @@ use pin_project::{pin_project, pinned_drop};
 use crate::{
     Piece,
     eviction::{Eviction, Op},
-    indexer::{Indexer, sentry::Sentry},
+    indexer::{Indexer, hash_table::HashTableIndexer, sentry::Sentry},
     inflight::{
         Enqueue, FetchOrTake, FetchTarget, InflightManager, Notifier, OptionalFetch, OptionalFetchBuilder,
         RequiredFetch, RequiredFetchBuilder, Waiter,
@@ -360,6 +360,42 @@ where
     }
 }
 
+impl<E, S> RawCacheShard<E, S, HashTableIndexer<E>>
+where
+    E: Eviction,
+    S: HashBuilder,
+{
+    fn evict_if<F>(&mut self, predicate: &mut F, garbages: &mut Vec<(Event, Arc<Record<E>>)>)
+    where
+        F: FnMut(&E::Key, &E::Value) -> bool + ?Sized,
+    {
+        let Self {
+            eviction,
+            indexer,
+            usage,
+            entries,
+            metrics,
+            ..
+        } = self;
+
+        for record in indexer.extract_if(|record| predicate(record.key(), record.value())) {
+            if record.is_in_eviction() {
+                eviction.remove(&record);
+            }
+            strict_assert!(!record.is_in_indexer());
+            strict_assert!(!record.is_in_eviction());
+
+            *usage -= record.weight();
+            *entries -= 1;
+            metrics.memory_evict.increase(1);
+            metrics.memory_usage.decrease(record.weight() as _);
+            metrics.memory_entries.decrease(1);
+
+            garbages.push((Event::Evict, record));
+        }
+    }
+}
+
 struct RawCacheInner<E, S, I>
 where
     E: Eviction,
@@ -660,6 +696,10 @@ where
             shard.write().evict(0, &mut garbages);
         }
 
+        self.flush_garbages(garbages).await;
+    }
+
+    async fn flush_garbages(&self, garbages: Vec<(Event, Arc<Record<E>>)>) {
         // Deallocate data out of the lock critical section.
         let piped = self.pipe.is_enabled();
 
@@ -797,6 +837,31 @@ where
         let base = total / shards;
         let remainder = total % shards;
         base + usize::from(index < remainder)
+    }
+}
+
+impl<E, S> RawCache<E, S, HashTableIndexer<E>>
+where
+    E: Eviction,
+    S: HashBuilder,
+{
+    /// Evict entries matching the predicate and offload them into the disk cache via the pipe if needed.
+    ///
+    /// This function obeys the io throttler of the disk cache and makes sure all matching entries are offloaded.
+    ///
+    /// The predicate is called while holding a shard lock and must not access this cache.
+    #[cfg_attr(feature = "tracing", fastrace::trace(name = "foyer::memory::raw::flush_if"))]
+    pub async fn flush_if<F>(&self, mut predicate: F)
+    where
+        F: FnMut(&E::Key, &E::Value) -> bool,
+    {
+        let mut garbages = vec![];
+        for shard in self.inner.shards.iter() {
+            shard.write().evict_if(&mut predicate, &mut garbages);
+        }
+
+        drop(predicate);
+        self.flush_garbages(garbages).await;
     }
 }
 
@@ -1657,6 +1722,50 @@ mod tests {
         pieces.sort_by_key(|t| t.0);
         let expected = (0..fifo.capacity() as u64).map(|i| (i, i, i)).collect_vec();
         assert_eq!(pieces, expected);
+    }
+
+    async fn assert_flush_if<E>(cache: RawCache<E, ModHasher, HashTableIndexer<E>>)
+    where
+        E: Eviction<Key = u64, Value = u64, Properties = TestProperties>,
+    {
+        let pipe = Arc::new(PiecePipe::default());
+        let cache = cache.with_pipe(pipe.clone());
+
+        for key in 0..8 {
+            cache.insert(key, key * 10);
+        }
+        let pinned = cache.insert(8, 80);
+
+        cache
+            .flush_if(|key, value| (key % 2 == 0 && *value < 60) || *key == 8)
+            .await;
+
+        let mut pieces = pipe
+            .pieces()
+            .iter()
+            .map(|piece| (*piece.key(), *piece.value()))
+            .collect_vec();
+        pieces.sort_unstable();
+        assert_eq!(pieces, vec![(0, 0), (2, 20), (4, 40), (8, 80)]);
+        assert_eq!(cache.entries(), 5);
+        assert_eq!(cache.usage(), 5);
+        assert!(pinned.is_outdated());
+
+        for key in [0, 2, 4, 8] {
+            assert!(cache.get(&key).is_none());
+        }
+        for key in [1, 3, 5, 6, 7] {
+            assert_eq!(*cache.get(&key).unwrap().value(), key * 10);
+        }
+    }
+
+    #[tokio::test]
+    async fn test_flush_if() {
+        assert_flush_if(fifo_cache_for_test()).await;
+        assert_flush_if(s3fifo_cache_for_test()).await;
+        assert_flush_if(lru_cache_for_test()).await;
+        assert_flush_if(lfu_cache_for_test()).await;
+        assert_flush_if(sieve_cache_for_test()).await;
     }
 
     #[test]

--- a/foyer/src/hybrid/cache.rs
+++ b/foyer/src/hybrid/cache.rs
@@ -1461,6 +1461,25 @@ mod tests {
     }
 
     #[test_log::test(tokio::test)]
+    async fn test_flush_if() {
+        let dir = tempfile::tempdir().unwrap();
+        let hybrid = open(dir.path()).await;
+        hybrid.insert(1, vec![1; 7 * KB]);
+        hybrid.insert(2, vec![2; 7 * KB]);
+
+        hybrid.memory().flush_if(|key, _| *key == 1).await;
+        hybrid.storage().wait().await;
+
+        assert!(hybrid.memory().get(&1).is_none());
+        assert!(hybrid.memory().get(&2).is_some());
+        assert_eq!(
+            hybrid.storage().load(&1).await.unwrap().kv().unwrap(),
+            (1, vec![1; 7 * KB])
+        );
+        assert!(hybrid.storage().load(&2).await.unwrap().is_miss());
+    }
+
+    #[test_log::test(tokio::test)]
     async fn test_load_after_recovery() {
         let open = |dir| async move {
             HybridCacheBuilder::new()

--- a/foyer/src/hybrid/cache.rs
+++ b/foyer/src/hybrid/cache.rs
@@ -612,6 +612,19 @@ where
         Ok(())
     }
 
+    /// Flush in-memory entries matching the predicate to the disk cache.
+    ///
+    /// The matching entries are removed from the in-memory cache. This function obeys the io throttler of the disk
+    /// cache and makes sure all matching entries are offloaded.
+    ///
+    /// The predicate is called while holding a shard lock and must not access this cache.
+    pub async fn flush_if<F>(&self, predicate: F)
+    where
+        F: FnMut(&K, &V) -> bool,
+    {
+        self.inner.memory.flush_if(predicate).await;
+    }
+
     /// Gracefully close the hybrid cache.
     ///
     /// `close` will wait for the ongoing flush and reclaim tasks to finish.
@@ -1467,7 +1480,7 @@ mod tests {
         hybrid.insert(1, vec![1; 7 * KB]);
         hybrid.insert(2, vec![2; 7 * KB]);
 
-        hybrid.memory().flush_if(|key, _| *key == 1).await;
+        hybrid.flush_if(|key, _| *key == 1).await;
         hybrid.storage().wait().await;
 
         assert!(hybrid.memory().get(&1).is_none());


### PR DESCRIPTION
## Summary

- add HybridCache::flush_if and Cache::flush_if for selectively evicting and offloading in-memory entries
- scan the hash index directly while keeping eviction state, metrics, and listeners consistent
- reuse the existing throttled pipe flush path without changing public eviction or indexer traits
- cover all eviction policies, pinned entries, and hybrid-cache disk persistence

## Testing

- cargo test -p foyer-memory
- cargo test -p foyer --lib
- cargo check --workspace

Closes #1319