### PR TITLE
feat(storage): validate engine-device compatibility statically

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,6 +26,7 @@ exclude = ["website/*"]
 [workspace.dependencies]
 allocator-api2 = "0.2"
 anyhow = "1"
+asyncband = "0.6.7"
 bincode = "1"
 bitflags = "2"
 bytes = "1"
@@ -61,7 +62,6 @@ itertools = { version = "0.15.0" }
 jiff = { version = "0.2.16" }
 libc = "0.2"
 lz4 = "1"
-asyncband = "0.6.7"
 mixtrics = "0.2"
 moka = "0.12"
 opentelemetry = { version = "0.32.0" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -91,6 +91,7 @@ tokio = { package = "foyer-tokio", version = "0.23.0-dev", path = "foyer-tokio",
 tonic = { version = "0.14.6", default-features = false }
 tracing = "0.1"
 tracing-subscriber = "0.3"
+trybuild = "1"
 twox-hash = { version = "2.1.2", default-features = false }
 zstd = "0.13"
 

--- a/examples/Cargo.toml
+++ b/examples/Cargo.toml
@@ -13,6 +13,12 @@ readme.workspace = true
 exclude.workspace = true
 publish = false
 
+# `tonic` is not used directly in example code, but it must be listed as a dep so the `otel` feature
+# can opt into the tonic-backed gRPC transport for `opentelemetry-otlp` (`grpc-tonic`).
+# Tell cargo-machete to ignore it so CI doesn't flag it as unused.
+[package.metadata.cargo-machete]
+ignored = ["tonic"]
+
 [features]
 serde = ["foyer/serde"]
 otel = [
@@ -53,12 +59,6 @@ tempfile = { workspace = true }
 tokio = { workspace = true, features = ["full"] }
 tonic = { workspace = true, optional = true }
 tracing = { workspace = true }
-
-# `tonic` is not used directly in example code, but it must be listed as a dep so the `otel` feature
-# can opt into the tonic-backed gRPC transport for `opentelemetry-otlp` (`grpc-tonic`).
-# Tell cargo-machete to ignore it so CI doesn't flag it as unused.
-[package.metadata.cargo-machete]
-ignored = ["tonic"]
 
 [[example]]
 name = "memory"

--- a/foyer-bench/Cargo.toml
+++ b/foyer-bench/Cargo.toml
@@ -30,6 +30,7 @@ tracing = [
 
 [dependencies]
 anyhow = { workspace = true }
+asyncband = { workspace = true }
 bytesize = { workspace = true }
 clap = { workspace = true }
 console-subscriber = { workspace = true, optional = true }
@@ -48,7 +49,6 @@ humantime = { workspace = true }
 hyper = { workspace = true, features = ["server", "http1"] }
 hyper-util = { workspace = true, features = ["tokio"] }
 itertools = { workspace = true }
-asyncband = { workspace = true }
 mixtrics = { workspace = true, features = ["prometheus"] }
 opentelemetry = { workspace = true, optional = true }
 opentelemetry-otlp = { workspace = true, features = [

--- a/foyer-bench/src/main.rs
+++ b/foyer-bench/src/main.rs
@@ -41,7 +41,7 @@ use exporter::PrometheusExporter;
 #[cfg(target_os = "linux")]
 use foyer::UringIoEngineConfig;
 use foyer::{
-    BlockEngineConfig, Code, Compression, Device, DeviceBuilder, EngineConfig, FifoConfig, FifoPicker,
+    BlockEngineConfig, Code, Compression, DeviceBuilder, DeviceFor, EngineConfig, FifoConfig, FifoPicker,
     FileDeviceBuilder, FsDeviceBuilder, HybridCache, HybridCacheBuilder, HybridCachePolicy, HybridCacheProperties,
     InvalidRatioPicker, IoEngineConfig, LfuConfig, LruConfig, NoopDeviceBuilder, PsyncIoEngineConfig, RecoverMode,
     S3FifoConfig, Spawner, Throttle, TracingOptions,
@@ -482,6 +482,28 @@ fn main() {
     runtime.block_on(benchmark(args));
 }
 
+fn block_engine_config<D>(device: Arc<D>, args: &Args) -> Box<dyn EngineConfig<u64, Value, HybridCacheProperties>>
+where
+    D: DeviceFor<BlockEngineConfig<u64, Value, HybridCacheProperties>>,
+{
+    let mut config = BlockEngineConfig::new(device)
+        .with_block_size(args.block_size.as_u64() as _)
+        .with_indexer_shards(args.shards)
+        .with_recover_concurrency(args.recover_concurrency)
+        .with_flushers(args.flushers)
+        .with_reclaimers(args.reclaimers)
+        .with_eviction_pickers(vec![
+            Box::new(InvalidRatioPicker::new(args.invalid_ratio)),
+            Box::new(FifoPicker::new(args.block_engine_fifo_probation_ratio)),
+        ])
+        .with_buffer_pool_size(args.buffer_pool_size.as_u64() as _)
+        .with_blob_index_size(args.blob_index_size.as_u64() as _);
+    if args.clean_block_threshold > 0 {
+        config = config.with_clean_block_threshold(args.clean_block_threshold);
+    }
+    config.boxed()
+}
+
 async fn benchmark(args: Args) {
     setup();
 
@@ -579,7 +601,7 @@ async fn benchmark(args: Args) {
         .with_read_throughput(args.disk_read_throughput.as_u64() as _)
         .with_write_throughput(args.disk_write_throughput.as_u64() as _);
 
-    let device: Arc<dyn Device> = match (args.file.as_ref(), args.dir.as_ref()) {
+    let engine_config = match (args.file.as_ref(), args.dir.as_ref()) {
         (Some(file), None) => {
             let mut builder = FileDeviceBuilder::new(file);
             builder = builder.with_capacity(args.disk.as_u64() as _).with_throttle(throttle);
@@ -587,7 +609,7 @@ async fn benchmark(args: Args) {
             {
                 builder = builder.with_direct(args.direct);
             }
-            builder.build().unwrap()
+            block_engine_config(builder.build().unwrap(), &args)
         }
         (None, Some(dir)) => {
             let mut builder = FsDeviceBuilder::new(dir);
@@ -596,9 +618,9 @@ async fn benchmark(args: Args) {
             {
                 builder = builder.with_direct(args.direct);
             }
-            builder.build().unwrap()
+            block_engine_config(builder.build().unwrap(), &args)
         }
-        (None, None) => NoopDeviceBuilder::default().build().unwrap(),
+        (None, None) => block_engine_config(NoopDeviceBuilder::default().build().unwrap(), &args),
         _ => unreachable!(),
     };
 
@@ -628,26 +650,6 @@ async fn benchmark(args: Args) {
             .boxed(),
         _ => unreachable!(),
     };
-
-    let engine_config: Box<dyn EngineConfig<u64, Value, HybridCacheProperties>> = {
-        let mut builder = BlockEngineConfig::new(device)
-            .with_block_size(args.block_size.as_u64() as _)
-            .with_indexer_shards(args.shards)
-            .with_recover_concurrency(args.recover_concurrency)
-            .with_flushers(args.flushers)
-            .with_reclaimers(args.reclaimers)
-            .with_eviction_pickers(vec![
-                Box::new(InvalidRatioPicker::new(args.invalid_ratio)),
-                Box::new(FifoPicker::new(args.block_engine_fifo_probation_ratio)),
-            ])
-            .with_buffer_pool_size(args.buffer_pool_size.as_u64() as _)
-            .with_blob_index_size(args.blob_index_size.as_u64() as _);
-        if args.clean_block_threshold > 0 {
-            builder = builder.with_clean_block_threshold(args.clean_block_threshold);
-        }
-        builder
-    }
-    .boxed();
 
     let mut builder = builder
         .with_weighter(|_: &u64, value: &Value| u64::BITS as usize / 8 + value.len())

--- a/foyer-common/src/error.rs
+++ b/foyer-common/src/error.rs
@@ -47,7 +47,7 @@ pub enum ErrorKind {
     MagicMismatch,
     /// Out of range.
     OutOfRange,
-    /// No sapce.
+    /// No space.
     NoSpace,
     /// Closed.
     Closed,

--- a/foyer-memory/Cargo.toml
+++ b/foyer-memory/Cargo.toml
@@ -22,6 +22,7 @@ tracing = ["dep:fastrace", "foyer-common/tracing"]
 
 [dependencies]
 anyhow = { workspace = true }
+asyncband = { workspace = true }
 bitflags = { workspace = true }
 datasketches = { workspace = true, features = ["countmin"] }
 equivalent = { workspace = true }
@@ -31,7 +32,6 @@ futures-util = { workspace = true }
 hashbrown = { workspace = true }
 intrusive-collections = { workspace = true }
 itertools = { workspace = true }
-asyncband = { workspace = true }
 mixtrics = { workspace = true }
 parking_lot = { workspace = true }
 paste = { workspace = true }

--- a/foyer-storage/Cargo.toml
+++ b/foyer-storage/Cargo.toml
@@ -28,6 +28,7 @@ strict_assertions = [
 [dependencies]
 allocator-api2 = { workspace = true }
 anyhow = { workspace = true }
+asyncband = { workspace = true }
 bytes = { workspace = true }
 clap = { workspace = true, optional = true }
 equivalent = { workspace = true }
@@ -42,7 +43,6 @@ hashbrown = { workspace = true }
 itertools = { workspace = true }
 libc = { workspace = true }
 lz4 = { workspace = true }
-asyncband = { workspace = true }
 parking_lot = { workspace = true }
 pin-project = { workspace = true }
 rand = { workspace = true, features = ["thread_rng"] }

--- a/foyer-storage/Cargo.toml
+++ b/foyer-storage/Cargo.toml
@@ -62,6 +62,7 @@ foyer-memory = { workspace = true, features = ["test_utils"] }
 tempfile = { workspace = true }
 test-log = { workspace = true, features = ["trace", "color"] }
 tokio = { workspace = true }
+trybuild = { workspace = true }
 
 [lints]
 workspace = true

--- a/foyer-storage/src/engine/block/engine.rs
+++ b/foyer-storage/src/engine/block/engine.rs
@@ -49,7 +49,7 @@ use super::{
 #[cfg(any(test, feature = "test_utils"))]
 use crate::test_utils::*;
 use crate::{
-    Device, Load, RejectAll, StorageFilter, StorageFilterResult,
+    Device, DeviceFor, Load, RejectAll, StorageFilter, StorageFilterResult,
     compress::Compression,
     engine::{
         Engine, EngineBuildContext, EngineConfig, Populated,
@@ -137,7 +137,11 @@ where
     P: Properties,
 {
     /// Create a new block-based disk cache engine builder with default configurations.
-    pub fn new(device: Arc<dyn Device>) -> Self {
+    pub fn new<D>(device: Arc<D>) -> Self
+    where
+        D: DeviceFor<Self>,
+    {
+        let device: Arc<dyn Device> = device;
         Self {
             device,
             block_size: 16 * 1024 * 1024, // 16 MiB

--- a/foyer-storage/src/engine/block/tombstone.rs
+++ b/foyer-storage/src/engine/block/tombstone.rs
@@ -252,7 +252,7 @@ mod tests {
     use crate::{
         IoEngineConfig, PsyncIoEngineConfig,
         io::{
-            device::{DeviceBuilder, fs::FsDeviceBuilder},
+            device::{Device, DeviceBuilder, fs::FsDeviceBuilder},
             engine::IoEngineBuildContext,
         },
     };

--- a/foyer-storage/src/engine/compatibility.rs
+++ b/foyer-storage/src/engine/compatibility.rs
@@ -1,0 +1,65 @@
+// Copyright 2026 foyer Project Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use foyer_common::{
+    code::{StorageKey, StorageValue},
+    properties::Properties,
+};
+
+use crate::{
+    engine::block::engine::BlockEngineConfig,
+    io::device::{
+        DeviceFor, combined::CombinedDevice, file::FileDevice, fs::FsDevice, noop::NoopDevice, partial::PartialDevice,
+    },
+};
+
+impl<K, V, P> DeviceFor<BlockEngineConfig<K, V, P>> for FsDevice
+where
+    K: StorageKey,
+    V: StorageValue,
+    P: Properties,
+{
+}
+
+impl<K, V, P> DeviceFor<BlockEngineConfig<K, V, P>> for FileDevice
+where
+    K: StorageKey,
+    V: StorageValue,
+    P: Properties,
+{
+}
+
+impl<K, V, P> DeviceFor<BlockEngineConfig<K, V, P>> for CombinedDevice
+where
+    K: StorageKey,
+    V: StorageValue,
+    P: Properties,
+{
+}
+
+impl<K, V, P> DeviceFor<BlockEngineConfig<K, V, P>> for PartialDevice
+where
+    K: StorageKey,
+    V: StorageValue,
+    P: Properties,
+{
+}
+
+impl<K, V, P> DeviceFor<BlockEngineConfig<K, V, P>> for NoopDevice
+where
+    K: StorageKey,
+    V: StorageValue,
+    P: Properties,
+{
+}

--- a/foyer-storage/src/engine/mod.rs
+++ b/foyer-storage/src/engine/mod.rs
@@ -195,4 +195,5 @@ where
 }
 
 pub mod block;
+mod compatibility;
 pub mod noop;

--- a/foyer-storage/src/io/device/combined.rs
+++ b/foyer-storage/src/io/device/combined.rs
@@ -63,7 +63,9 @@ impl CombinedDeviceBuilder {
 }
 
 impl DeviceBuilder for CombinedDeviceBuilder {
-    fn build(self) -> Result<Arc<dyn Device>> {
+    type Device = CombinedDevice;
+
+    fn build(self) -> Result<Arc<Self::Device>> {
         let device = CombinedDevice {
             devices: self.devices,
             statistics: Arc::new(Statistics::new(self.throttle)),

--- a/foyer-storage/src/io/device/file.rs
+++ b/foyer-storage/src/io/device/file.rs
@@ -76,7 +76,9 @@ impl FileDeviceBuilder {
 }
 
 impl DeviceBuilder for FileDeviceBuilder {
-    fn build(self) -> Result<Arc<dyn Device>> {
+    type Device = FileDevice;
+
+    fn build(self) -> Result<Arc<Self::Device>> {
         // Normalize configurations.
 
         let align_v = |value: usize, align: usize| value - (value % align);
@@ -133,8 +135,7 @@ impl DeviceBuilder for FileDeviceBuilder {
             statistics,
             partitions: RwLock::new(vec![]),
         };
-        let device: Arc<dyn Device> = Arc::new(device);
-        Ok(device)
+        Ok(Arc::new(device))
     }
 }
 

--- a/foyer-storage/src/io/device/fs.rs
+++ b/foyer-storage/src/io/device/fs.rs
@@ -76,7 +76,9 @@ impl FsDeviceBuilder {
 }
 
 impl DeviceBuilder for FsDeviceBuilder {
-    fn build(self) -> Result<Arc<dyn Device>> {
+    type Device = FsDevice;
+
+    fn build(self) -> Result<Arc<Self::Device>> {
         // Normalize configurations.
 
         let align_v = |value: usize, align: usize| value - value % align;
@@ -104,8 +106,7 @@ impl DeviceBuilder for FsDeviceBuilder {
             direct: self.direct,
             partitions: RwLock::new(vec![]),
         };
-        let device: Arc<dyn Device> = Arc::new(device);
-        Ok(device)
+        Ok(Arc::new(device))
     }
 }
 

--- a/foyer-storage/src/io/device/mod.rs
+++ b/foyer-storage/src/io/device/mod.rs
@@ -22,6 +22,7 @@ use foyer_common::error::Result;
 
 use crate::io::device::statistics::Statistics;
 
+/// Identifier of a device partition.
 pub type PartitionId = u32;
 
 /// Raw os file resource.
@@ -41,9 +42,21 @@ unsafe impl Sync for RawFile {}
 
 /// Device builder trait.
 pub trait DeviceBuilder: Send + Sync + 'static + Debug {
+    /// Device built by this builder.
+    type Device: Device;
+
     /// Build a device from the given configuration.
-    fn build(self) -> Result<Arc<dyn Device>>;
+    fn build(self) -> Result<Arc<Self::Device>>;
 }
+
+/// Marker trait for devices supported by an engine config.
+///
+/// Implementations form the compile-time compatibility list between engine configs and devices.
+#[diagnostic::on_unimplemented(
+    message = "device `{Self}` is not compatible with engine config `{E}`",
+    label = "unsupported engine-device combination"
+)]
+pub trait DeviceFor<E: ?Sized>: Device {}
 
 /// Partition is a logical segment of a device.
 pub trait Partition: Send + Sync + 'static + Debug + Any {

--- a/foyer-storage/src/io/device/noop.rs
+++ b/foyer-storage/src/io/device/noop.rs
@@ -41,7 +41,9 @@ impl Default for NoopDeviceBuilder {
 }
 
 impl DeviceBuilder for NoopDeviceBuilder {
-    fn build(self) -> Result<Arc<dyn Device>> {
+    type Device = NoopDevice;
+
+    fn build(self) -> Result<Arc<Self::Device>> {
         let statistics = Arc::new(Statistics::new(Throttle::default()));
         Ok(Arc::new(NoopDevice {
             partitions: RwLock::new(vec![]),
@@ -52,6 +54,7 @@ impl DeviceBuilder for NoopDeviceBuilder {
 }
 
 #[derive(Debug)]
+/// A no-operation mock device.
 pub struct NoopDevice {
     partitions: RwLock<Vec<Arc<NoopPartition>>>,
 

--- a/foyer-storage/src/io/device/partial.rs
+++ b/foyer-storage/src/io/device/partial.rs
@@ -46,7 +46,9 @@ impl PartialDeviceBuilder {
 }
 
 impl DeviceBuilder for PartialDeviceBuilder {
-    fn build(self) -> Result<Arc<dyn Device>> {
+    type Device = PartialDevice;
+
+    fn build(self) -> Result<Arc<Self::Device>> {
         Ok(Arc::new(PartialDevice {
             inner: self.device,
             capacity: self.capacity,

--- a/foyer-storage/src/prelude.rs
+++ b/foyer-storage/src/prelude.rs
@@ -30,12 +30,12 @@ pub use crate::{
     },
     io::{
         device::{
-            Device, DeviceBuilder, RawFile,
-            combined::CombinedDeviceBuilder,
-            file::FileDeviceBuilder,
-            fs::FsDeviceBuilder,
-            noop::NoopDeviceBuilder,
-            partial::PartialDeviceBuilder,
+            Device, DeviceBuilder, DeviceFor, Partition, PartitionId, RawFile,
+            combined::{CombinedDevice, CombinedDeviceBuilder},
+            file::{FileDevice, FileDeviceBuilder},
+            fs::{FsDevice, FsDeviceBuilder},
+            noop::{NoopDevice, NoopDeviceBuilder},
+            partial::{PartialDevice, PartialDeviceBuilder},
             statistics::Statistics,
             throttle::{IopsCounter, Throttle},
         },
@@ -47,3 +47,4 @@ pub use crate::{
     },
     store::{Store, StoreBuilder},
 };
+pub use foyer_common::error::{Error, ErrorKind, Result};

--- a/foyer-storage/src/prelude.rs
+++ b/foyer-storage/src/prelude.rs
@@ -12,6 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+pub use foyer_common::error::{Error, ErrorKind, Result};
+
 #[cfg(target_os = "linux")]
 pub use crate::io::engine::uring::{UringIoEngine, UringIoEngineConfig};
 pub use crate::{
@@ -47,4 +49,3 @@ pub use crate::{
     },
     store::{Store, StoreBuilder},
 };
-pub use foyer_common::error::{Error, ErrorKind, Result};

--- a/foyer-storage/tests/engine_device_compatibility.rs
+++ b/foyer-storage/tests/engine_device_compatibility.rs
@@ -14,6 +14,7 @@
 
 //! Compile-time tests for engine-device compatibility declarations.
 
+#[cfg(not(madsim))]
 #[test]
 fn engine_device_compatibility() {
     let tests = trybuild::TestCases::new();

--- a/foyer-storage/tests/engine_device_compatibility.rs
+++ b/foyer-storage/tests/engine_device_compatibility.rs
@@ -1,0 +1,23 @@
+// Copyright 2026 foyer Project Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+//! Compile-time tests for engine-device compatibility declarations.
+
+#[test]
+fn engine_device_compatibility() {
+    let tests = trybuild::TestCases::new();
+    tests.pass("tests/ui/engine_device_compatibility/supported.rs");
+    tests.pass("tests/ui/engine_device_compatibility/downstream_extension.rs");
+    tests.compile_fail("tests/ui/engine_device_compatibility/unsupported.rs");
+}

--- a/foyer-storage/tests/ui/engine_device_compatibility/downstream_extension.rs
+++ b/foyer-storage/tests/ui/engine_device_compatibility/downstream_extension.rs
@@ -1,0 +1,68 @@
+// Copyright 2026 foyer Project Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use std::sync::Arc;
+
+use foyer_memory::CacheProperties;
+use foyer_storage::{
+    BlockEngineConfig, Device, DeviceFor, FsDevice, Partition, PartitionId, Statistics,
+};
+
+type Config = BlockEngineConfig<u64, u64, CacheProperties>;
+
+#[derive(Debug)]
+struct CustomDevice;
+
+impl Device for CustomDevice {
+    fn capacity(&self) -> usize {
+        unimplemented!()
+    }
+
+    fn allocated(&self) -> usize {
+        unimplemented!()
+    }
+
+    fn create_partition(&self, _: usize) -> foyer_storage::Result<Arc<dyn Partition>> {
+        unimplemented!()
+    }
+
+    fn partitions(&self) -> usize {
+        unimplemented!()
+    }
+
+    fn partition(&self, _: PartitionId) -> Arc<dyn Partition> {
+        unimplemented!()
+    }
+
+    fn statistics(&self) -> &Arc<Statistics> {
+        unimplemented!()
+    }
+}
+
+impl DeviceFor<Config> for CustomDevice {}
+
+struct CustomEngineConfig;
+
+impl DeviceFor<CustomEngineConfig> for FsDevice {}
+
+fn assert_compatible<E, D>()
+where
+    D: DeviceFor<E>,
+{
+}
+
+fn main() {
+    assert_compatible::<Config, CustomDevice>();
+    assert_compatible::<CustomEngineConfig, FsDevice>();
+}

--- a/foyer-storage/tests/ui/engine_device_compatibility/supported.rs
+++ b/foyer-storage/tests/ui/engine_device_compatibility/supported.rs
@@ -1,0 +1,39 @@
+// Copyright 2026 foyer Project Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use foyer_memory::CacheProperties;
+use foyer_storage::{
+    BlockEngineConfig, CombinedDevice, DeviceBuilder, DeviceFor, FileDevice, FsDevice, FsDeviceBuilder, NoopDevice,
+    PartialDevice,
+};
+
+type Config = BlockEngineConfig<u64, u64, CacheProperties>;
+
+fn assert_compatible<D>()
+where
+    D: DeviceFor<Config>,
+{
+}
+
+fn main() -> foyer_storage::Result<()> {
+    assert_compatible::<FsDevice>();
+    assert_compatible::<FileDevice>();
+    assert_compatible::<CombinedDevice>();
+    assert_compatible::<PartialDevice>();
+    assert_compatible::<NoopDevice>();
+
+    let device = FsDeviceBuilder::new("cache").build()?;
+    let _config: Config = BlockEngineConfig::new(device);
+    Ok(())
+}

--- a/foyer-storage/tests/ui/engine_device_compatibility/unsupported.rs
+++ b/foyer-storage/tests/ui/engine_device_compatibility/unsupported.rs
@@ -1,0 +1,52 @@
+// Copyright 2026 foyer Project Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use std::sync::Arc;
+
+use foyer_memory::CacheProperties;
+use foyer_storage::{BlockEngineConfig, Device, Partition, PartitionId, Statistics};
+
+#[derive(Debug)]
+struct UnsupportedDevice;
+
+impl Device for UnsupportedDevice {
+    fn capacity(&self) -> usize {
+        unimplemented!()
+    }
+
+    fn allocated(&self) -> usize {
+        unimplemented!()
+    }
+
+    fn create_partition(&self, _: usize) -> foyer_storage::Result<Arc<dyn Partition>> {
+        unimplemented!()
+    }
+
+    fn partitions(&self) -> usize {
+        unimplemented!()
+    }
+
+    fn partition(&self, _: PartitionId) -> Arc<dyn Partition> {
+        unimplemented!()
+    }
+
+    fn statistics(&self) -> &Arc<Statistics> {
+        unimplemented!()
+    }
+}
+
+fn main() {
+    let device = Arc::new(UnsupportedDevice);
+    let _: BlockEngineConfig<u64, u64, CacheProperties> = BlockEngineConfig::new(device);
+}

--- a/foyer-storage/tests/ui/engine_device_compatibility/unsupported.stderr
+++ b/foyer-storage/tests/ui/engine_device_compatibility/unsupported.stderr
@@ -1,0 +1,27 @@
+error[E0277]: device `UnsupportedDevice` is not compatible with engine config `BlockEngineConfig<_, _, _>`
+  --> tests/ui/engine_device_compatibility/unsupported.rs:51:82
+   |
+51 |     let _: BlockEngineConfig<u64, u64, CacheProperties> = BlockEngineConfig::new(device);
+   |                                                           ---------------------- ^^^^^^ unsupported engine-device combination
+   |                                                           |
+   |                                                           required by a bound introduced by this call
+   |
+help: the trait `DeviceFor<BlockEngineConfig<_, _, _>>` is not implemented for `UnsupportedDevice`
+  --> tests/ui/engine_device_compatibility/unsupported.rs:21:1
+   |
+21 | struct UnsupportedDevice;
+   | ^^^^^^^^^^^^^^^^^^^^^^^^
+   = help: the following other types implement trait `DeviceFor<E>`:
+             CombinedDevice
+             FileDevice
+             FsDevice
+             NoopDevice
+             PartialDevice
+note: required by a bound in `BlockEngineConfig::<K, V, P>::new`
+  --> src/engine/block/engine.rs
+   |
+   |     pub fn new<D>(device: Arc<D>) -> Self
+   |            --- required by a bound in this associated function
+   |     where
+   |         D: DeviceFor<Self>,
+   |            ^^^^^^^^^^^^^^^ required by this bound in `BlockEngineConfig::<K, V, P>::new`

--- a/foyer/Cargo.toml
+++ b/foyer/Cargo.toml
@@ -43,13 +43,13 @@ runtime-madsim-tokio = ["tokio/runtime-madsim-tokio"]
 
 [dependencies]
 anyhow = { workspace = true }
+asyncband = { workspace = true }
 equivalent = { workspace = true }
 fastrace = { workspace = true, optional = true }
 foyer-common = { workspace = true }
 foyer-memory = { workspace = true }
 foyer-storage = { workspace = true }
 futures-util = { workspace = true }
-asyncband = { workspace = true }
 mixtrics = { workspace = true }
 pin-project = { workspace = true }
 serde = { workspace = true }

--- a/foyer/src/prelude.rs
+++ b/foyer/src/prelude.rs
@@ -36,11 +36,12 @@ pub use crate::{
         LruConfig, S3FifoConfig, SieveConfig, Weighter,
     },
     storage::{
-        AdmitAll, Block, BlockEngineConfig, BlockStatistics, CombinedDeviceBuilder, Compression, Device, DeviceBuilder,
-        Engine, EngineBuildContext, EngineConfig, EstimatedSize, EvictionInfo, EvictionPicker, FifoPicker,
-        FileDeviceBuilder, FsDeviceBuilder, InvalidRatioPicker, IoEngine, IoEngineConfig, IoHandle, IopsCounter, Load,
-        NoopDeviceBuilder, NoopIoEngine, NoopIoEngineConfig, PartialDeviceBuilder, PsyncIoEngine, PsyncIoEngineConfig,
-        RawFile, RecoverMode, RejectAll, Statistics, StorageFilter, StorageFilterCondition, StorageFilterResult, Store,
-        StoreBuilder, Throttle,
+        AdmitAll, Block, BlockEngineConfig, BlockStatistics, CombinedDevice, CombinedDeviceBuilder, Compression,
+        Device, DeviceBuilder, DeviceFor, Engine, EngineBuildContext, EngineConfig, EstimatedSize, EvictionInfo,
+        EvictionPicker, FifoPicker, FileDevice, FileDeviceBuilder, FsDevice, FsDeviceBuilder, InvalidRatioPicker,
+        IoEngine, IoEngineConfig, IoHandle, IopsCounter, Load, NoopDevice, NoopDeviceBuilder, NoopIoEngine,
+        NoopIoEngineConfig, PartialDevice, PartialDeviceBuilder, Partition, PartitionId, PsyncIoEngine,
+        PsyncIoEngineConfig, RawFile, RecoverMode, RejectAll, Statistics, StorageFilter, StorageFilterCondition,
+        StorageFilterResult, Store, StoreBuilder, Throttle,
     },
 };

--- a/xtask/src/main.rs
+++ b/xtask/src/main.rs
@@ -112,31 +112,7 @@ fn tools(yes: bool) {
         "cargo install cargo-nextest --locked",
         yes,
     );
-    check_and_install(
-        "license-eye",
-        "which license-eye",
-        &format!(
-            r#"
-            wget -P /tmp https://github.com/apache/skywalking-eyes/releases/download/v0.7.0/skywalking-license-eye-0.7.0-bin.tgz && \
-            tar -xzf /tmp/skywalking-license-eye-0.7.0-bin.tgz -C /tmp && \
-            cp /tmp/skywalking-license-eye-0.7.0-bin/bin/{}/license-eye ~/.cargo/bin/license-eye
-            "#,
-            if cfg!(target_os = "linux") {
-                "linux"
-            } else if cfg!(target_os = "macos") {
-                "darwin"
-            } else if cfg!(target_os = "windows") {
-                "windows"
-            } else {
-                println!(
-                    "Unsupported OS for {name} installation.",
-                    name = "license-eye".magenta()
-                );
-                exit(1);
-            },
-        ),
-        yes,
-    );
+    check_and_install("hawkeye", "which hawkeye", "cargo install hawkeye --locked", yes);
 }
 
 fn check(fast: bool) {
@@ -210,7 +186,7 @@ fn udeps() {
 }
 
 fn license() {
-    run("license-eye header check");
+    run("hawkeye check");
 }
 
 fn madsim() {


### PR DESCRIPTION
## Summary

- preserve concrete device types through `DeviceBuilder` and validate engine-device pairs before type erasure
- add the extensible `DeviceFor` marker trait, a centralized `BlockEngine` compatibility list, and targeted compiler diagnostics
- expose concrete device and partition types needed by downstream implementations
- move runtime device selection in `foyer-bench` after static engine-config construction
- add compile-pass and compile-fail coverage for built-in pairs and downstream extension paths
- keep compile-time UI tests isolated from the madsim runtime feature set
- align the local `cargo x` license step with CI's HawkEye configuration

## API compatibility

- `DeviceBuilder` now declares an associated `Device` type and returns `Arc<Self::Device>`
- `BlockEngineConfig::new` requires the concrete device type to implement `DeviceFor<Self>`
- callers that erase a device to `Arc<dyn Device>` before engine construction must delay erasure or erase the completed `EngineConfig` instead

## Testing

- `cargo x --fast`
- `RUSTFLAGS='--cfg tokio_unstable --cfg madsim' cargo nextest run --workspace --exclude foyer-bench --exclude examples --no-default-features --features 'runtime-madsim-tokio'`
