### PR TITLE
docs: clarify event_listener example expected output

### DIFF
--- a/examples/event_listener.rs
+++ b/examples/event_listener.rs
@@ -27,7 +27,12 @@ impl EventListener for EchoEventListener {
     }
 }
 
-/// Output:
+/// Expected output:
+///
+/// The first four lines are deterministic (replace / FIFO eviction while inserting).
+/// The last three lines are the remaining entries released when `cache` is dropped at
+/// the end of `main`; the keys are `100` / `101` / `102`, but the release order is not
+/// guaranteed, so they are written as `..` below.
 ///
 /// ```plain
 /// Entry [key = 2] [value = First] is released.


### PR DESCRIPTION
## Summary
- Clarify the expected-output comment in `examples/event_listener.rs`.
- Keep the existing `..` placeholders; document that they mean Drop-order of remaining keys is unspecified.

## Why
The trailing lines use `[key = ..]` instead of concrete keys (`100` / `101` / `102`). That looked like a typo vs a live run, but git history shows it was intentional in #1123 (author Croxx): after the deterministic replace/FIFO eviction lines, the cache still holds three entries that are only released when `cache` is dropped, and that release order is not guaranteed.

## How to validate
```bash
cargo run -p examples --example event_listener
```
- First four lines should match the comment exactly.
- Last three lines should be keys `100`/`101`/`102` with value `===`, in any order.

## Risk / rollout notes
Docs-only change; no runtime behavior impact.

Made with [Cursor](https://cursor.com)