### PR TITLE
docs: fix metrics example curl port

### DIFF
--- a/examples/export_metrics_prometheus_hyper.rs
+++ b/examples/export_metrics_prometheus_hyper.rs
@@ -106,7 +106,7 @@ async fn main() {
         .with_metrics_registry(Box::new(PrometheusMetricsRegistry::new(registry)))
         .build();
 
-    // > curl http://127.0.0.1:7890
+    // > curl http://127.0.0.1:19970
     //
     // # HELP foyer_hybrid_op_duration foyer hybrid cache operation durations
     // # TYPE foyer_hybrid_op_duration histogram


### PR DESCRIPTION
## What's changed and what's your intention?

The sample curl command in `examples/export_metrics_prometheus_hyper.rs` used port `7890`, while the exporter binds to `19970`. This updates the comment to match.

## Checklist
- [x] I have passed `cargo x --fast` in my local environment.