### PR TITLE
chore: release foyer v0.22.4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,42 @@ date: 2023-05-12T11:02:09+08:00
 
 <!-- truncate -->
 
+## 2026-08-31
+
+### Release
+
+| crate | version |
+| - | - |
+| foyer | 0.22.4 |
+| foyer-tokio | 0.22.4 |
+| foyer-common | 0.22.4 |
+| foyer-memory | 0.22.4 |
+| foyer-storage | 0.22.4 |
+| foyer-bench | 0.22.4 |
+
+### Changes
+
+> [!IMPORTANT]
+> **SemVer-incompatible changes:**
+>
+> - Raise the MSRV from Rust 1.85 to 1.91 and migrate to Rust 2024 edition. [#1258](https://github.com/foyer-rs/foyer/pull/1258) [#1275](https://github.com/foyer-rs/foyer/pull/1275) [#1303](https://github.com/foyer-rs/foyer/pull/1303)
+> - Add the `storage_false_positive` field to the publicly constructible `Metrics` struct and the `Unsupported` variant to the exhaustive `ErrorKind` enum. [#1261](https://github.com/foyer-rs/foyer/pull/1261) [#1271](https://github.com/foyer-rs/foyer/pull/1271)
+> - Remove the `as_any()` and `into_any()` methods from the public `IoB` trait. [#1281](https://github.com/foyer-rs/foyer/pull/1281)
+
+Features and enhancements:
+
+- Support selectively flushing matching entries from memory to storage with `Cache::flush_if()` and `HybridCache::flush_if()`. [#1320](https://github.com/foyer-rs/foyer/pull/1320)
+- Expose false-positive storage metrics. [#1261](https://github.com/foyer-rs/foyer/pull/1261)
+- Re-export `SieveConfig` from the `foyer` prelude. [#1285](https://github.com/foyer-rs/foyer/pull/1285)
+- Make `Throttle` constructors and builder methods usable in const contexts. [#1303](https://github.com/foyer-rs/foyer/pull/1303)
+
+Fixes:
+
+- Fix default file-device capacity detection for block devices. [#1271](https://github.com/foyer-rs/foyer/pull/1271)
+- Delete stale storage entries when admission rejects an update. [#1270](https://github.com/foyer-rs/foyer/pull/1270)
+- Fix stale tracing and debug information names. [#1276](https://github.com/foyer-rs/foyer/pull/1276)
+- Fix builds in Bazel sandboxed environments. [#1274](https://github.com/foyer-rs/foyer/pull/1274)
+
 ## 2026-01-23
 
 ### Release

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,7 +12,7 @@ members = [
 ]
 
 [workspace.package]
-version = "0.23.0-dev"
+version = "0.22.4"
 edition = "2024"
 rust-version = "1.91.0"
 repository = "https://github.com/foyer-rs/foyer"
@@ -42,10 +42,10 @@ equivalent = "1"
 fastant = { version = "0.1.11" }
 fastrace = { version = "0.7.18" }
 fastrace-opentelemetry = { version = "0.18.1" }
-foyer = { version = "0.23.0-dev", path = "foyer", default-features = false }
-foyer-common = { version = "0.23.0-dev", path = "foyer-common", default-features = false }
-foyer-memory = { version = "0.23.0-dev", path = "foyer-memory", default-features = false }
-foyer-storage = { version = "0.23.0-dev", path = "foyer-storage", default-features = false }
+foyer = { version = "0.22.4", path = "foyer", default-features = false }
+foyer-common = { version = "0.22.4", path = "foyer-common", default-features = false }
+foyer-memory = { version = "0.22.4", path = "foyer-memory", default-features = false }
+foyer-storage = { version = "0.22.4", path = "foyer-storage", default-features = false }
 fs4 = { version = "0.13", default-features = false }
 futures-core = { version = "0.3" }
 futures-util = { version = "0.3", default-features = false, features = ["std"] }
@@ -85,7 +85,7 @@ serde_json = "1"
 tempfile = "3"
 test-log = "0.2"
 tikv-jemallocator = "0.6"
-tokio = { package = "foyer-tokio", version = "0.23.0-dev", path = "foyer-tokio", default-features = false }
+tokio = { package = "foyer-tokio", version = "0.22.4", path = "foyer-tokio", default-features = false }
 # tonic 0.14.6 bumped its MSRV to 1.88; pin to <0.14.6 to keep the workspace MSRV at 1.86.
 # Pulled in transitively via opentelemetry-otlp (grpc-tonic feature) in `examples`.
 tonic = { version = "0.14.6", default-features = false }


### PR DESCRIPTION
## What's changed and what's your intention?

- Bump all workspace crates from `0.23.0-dev` to `0.22.4`.
- Add the `v0.22.4` release notes for changes between `v0.22.3` and the latest `main`.
- Record the SemVer incompatibilities found during the release audit.

## SemVer audit

> [!WARNING]
> The current `main` is not SemVer-compatible with `v0.22.3` as a patch release. Keep this PR in draft until the release strategy is resolved.

`cargo-semver-checks` found two major-level API violations in `foyer-common`:

- `Metrics` is publicly constructible and adds the public `storage_false_positive` field.
- `ErrorKind` is exhaustive and adds the `Unsupported` variant.

Manual review found two additional compatibility issues:

- The workspace MSRV changes from Rust 1.85 to 1.91 and the edition changes from 2021 to 2024.
- The public `IoB` trait removes `as_any()` and `into_any()`.

The default-feature API checks passed for `foyer`, `foyer-memory`, `foyer-storage`, and `foyer-tokio`.

Recommended resolution: either publish these changes as `v0.23.0`, restore the incompatible APIs before publishing, or cut `v0.22.4` from `release-v0.22` with only compatible backports.

## Validation

- `cargo semver-checks check-release -p <crate> --baseline-rev v0.22.3 --release-type patch --default-features`
- `cargo +1.91.0 check --workspace --all-targets`
- `hawkeye check`
- `cargo x --fast --yes` passed formatting, clippy, 103 tests, doc tests, nightly docs, examples, and `cargo-machete`; its final legacy `license-eye header check` step crashed because it still expects the removed `.licenserc.yaml`. The equivalent current `hawkeye check` passed.

## Checklist

- [x] I have written the necessary rustdoc comments
- [x] I have added the necessary unit tests and integration tests
- [ ] I have passed `cargo x` (or `cargo x --fast` instead if the old tests are not modified)

## Related issues or PRs (optional)

None.
