### PR TITLE
docs: fix ErrorKind typo

### DIFF
--- a/foyer-common/src/error.rs
+++ b/foyer-common/src/error.rs
@@ -47,7 +47,7 @@ pub enum ErrorKind {
     MagicMismatch,
     /// Out of range.
     OutOfRange,
-    /// No sapce.
+    /// No space.
     NoSpace,
     /// Closed.
     Closed,


### PR DESCRIPTION
## What's changed and what's your intention?

Fix the `No sapce.` typo in the `ErrorKind::NoSpace` rustdoc that causes the CI typos check to fail.

## Validation

- `typos`
- `git diff --check`

## Checklist

- [x] I have written the necessary rustdoc comments
- [x] I have added the necessary unit tests and integration tests
- [x] I have passed the relevant local checks

## Related issues or PRs (optional)

- Unblocks the `misc check` on #1324.
