### PR TITLE
docs: backport v0.22.4 changelog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,35 @@ date: 2023-05-12T11:02:09+08:00
 
 <!-- truncate -->
 
+## 2026-08-31
+
+### Release
+
+| crate | version |
+| - | - |
+| foyer | 0.22.4 |
+| foyer-tokio | 0.22.4 |
+| foyer-common | 0.22.4 |
+| foyer-memory | 0.22.4 |
+| foyer-storage | 0.22.4 |
+| foyer-bench | 0.22.4 |
+
+### Changes
+
+Features and enhancements:
+
+- Support selectively flushing matching entries from memory to storage with `Cache::flush_if()` and `HybridCache::flush_if()`. [#1320](https://github.com/foyer-rs/foyer/pull/1320)
+- Expose false-positive storage metrics. [#1261](https://github.com/foyer-rs/foyer/pull/1261)
+- Re-export `SieveConfig` from the `foyer` prelude. [#1285](https://github.com/foyer-rs/foyer/pull/1285)
+- Make `Throttle` constructors and builder methods usable in const contexts. [#1303](https://github.com/foyer-rs/foyer/pull/1303)
+
+Fixes:
+
+- Fix default file-device capacity detection for block devices. [#1271](https://github.com/foyer-rs/foyer/pull/1271)
+- Delete stale storage entries when admission rejects an update. [#1270](https://github.com/foyer-rs/foyer/pull/1270)
+- Fix stale tracing and debug information names. [#1276](https://github.com/foyer-rs/foyer/pull/1276)
+- Fix builds in Bazel sandboxed environments. [#1274](https://github.com/foyer-rs/foyer/pull/1274)
+
 ## 2026-01-23
 
 ### Release


### PR DESCRIPTION
## What's changed and what's your intention?

- Backport the `v0.22.4` release notes from `release-v0.22` to `main`.
- Keep the workspace version at `0.23.0-dev`.

## Validation

- `typos CHANGELOG.md`
- `hawkeye check`
- `git diff --check`

## Checklist

- [x] I have written the necessary rustdoc comments
- [x] I have added the necessary unit tests and integration tests
- [x] I have passed the relevant local checks

## Related issues or PRs (optional)

- Follows #1326.
