### PR TITLE
fix(storage): defer entries that do not fit the flush buffer tail

### DIFF
--- a/foyer-storage/Cargo.toml
+++ b/foyer-storage/Cargo.toml
@@ -59,6 +59,8 @@ io-uring = { workspace = true }
 [dev-dependencies]
 bytesize = { workspace = true }
 foyer-memory = { workspace = true, features = ["test_utils"] }
+# Used to assert on the metrics counters in the unit tests.
+mixtrics = { workspace = true }
 tempfile = { workspace = true }
 test-log = { workspace = true, features = ["trace", "color"] }
 tokio = { workspace = true }

--- a/foyer-storage/src/engine/block/buffer.rs
+++ b/foyer-storage/src/engine/block/buffer.rs
@@ -165,6 +165,21 @@ impl BufferEntryInfo {
     }
 }
 
+/// The result of pushing an entry into a [`Buffer`].
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum Push {
+    /// The entry is written into the buffer.
+    Ok,
+    /// The entry doesn't fit the remaining space of the buffer.
+    ///
+    /// The entry can still be written after the buffer is rotated. But if the buffer that rejects the entry is already
+    /// empty, the entry is larger than the whole buffer, therefore it can never be written.
+    NoSpace,
+    /// The entry can never be written into a buffer, e.g. it is larger than the max entry size, or it fails to be
+    /// serialized.
+    Unstorable,
+}
+
 #[derive(Debug)]
 pub struct Buffer {
     bytes: IoSliceMut,
@@ -191,7 +206,7 @@ impl Buffer {
         self.entry_infos.is_empty()
     }
 
-    pub fn push<K, V>(&mut self, key: &K, value: &V, hash: u64, compression: Compression, sequence: Sequence) -> bool
+    pub fn push<K, V>(&mut self, key: &K, value: &V, hash: u64, compression: Compression, sequence: Sequence) -> Push
     where
         K: StorageKey,
         V: StorageValue,
@@ -201,9 +216,9 @@ impl Buffer {
         let offset = self.written;
         let buf = &mut self.bytes[offset..];
 
-        // If there is no space even for entry header, skip
+        // If there is no space even for entry header, the entry needs a rotated buffer.
         if buf.len() < EntryHeader::serialized_len() {
-            return false;
+            return Push::NoSpace;
         }
 
         let ser = Instant::now();
@@ -211,11 +226,14 @@ impl Buffer {
         let info = match EntrySerializer::serialize(key, value, compression, &mut buf[EntryHeader::serialized_len()..])
         {
             Ok(info) => info,
+            Err(e) if e.kind() == ErrorKind::BufferSizeLimit => {
+                // The entry doesn't fit the remaining space of the buffer, it needs a rotated buffer.
+                tracing::trace!(hash, ?e, "[blob writer]: no space left for the entry in the buffer");
+                return Push::NoSpace;
+            }
             Err(e) => {
-                if e.kind() != ErrorKind::BufferSizeLimit {
-                    tracing::warn!(?e, "[blob writer]: serialize entry kv error");
-                }
-                return false;
+                tracing::warn!(?e, "[blob writer]: serialize entry kv error");
+                return Push::Unstorable;
             }
         };
         let checksum = Checksummer::checksum64(
@@ -240,7 +258,7 @@ impl Buffer {
         let aligned = bits::align_up(PAGE, len);
 
         if aligned > self.max_entry_size {
-            return false;
+            return Push::Unstorable;
         }
 
         let info = BufferEntryInfo {
@@ -254,11 +272,11 @@ impl Buffer {
 
         tracing::trace!(hash, "[blob writer]: push finish");
 
-        true
+        Push::Ok
     }
 
     /// Serialize an serialized kv entry slice into the dest.
-    pub fn push_slice(&mut self, slice: &[u8], hash: u64, sequence: Sequence) -> bool {
+    pub fn push_slice(&mut self, slice: &[u8], hash: u64, sequence: Sequence) -> Push {
         tracing::trace!(hash, "[blob writer]: push slice");
 
         let offset = self.written;
@@ -267,8 +285,12 @@ impl Buffer {
         let len = slice.len();
         let aligned = bits::align_up(PAGE, slice.len());
 
-        if aligned > self.max_entry_size || aligned > buf.len() {
-            return false;
+        if aligned > self.max_entry_size {
+            return Push::Unstorable;
+        }
+
+        if aligned > buf.len() {
+            return Push::NoSpace;
         }
 
         buf[..slice.len()].copy_from_slice(slice);
@@ -284,7 +306,7 @@ impl Buffer {
 
         tracing::trace!(hash, "[blob writer]: push slice finish");
 
-        true
+        Push::Ok
     }
 
     pub fn finish(self) -> (IoSliceMut, Vec<BufferEntryInfo>) {
@@ -494,6 +516,8 @@ mod tests {
     use super::*;
 
     const KB: usize = 1024;
+    /// A 3 KiB entry is serialized into a bit more than 3 KiB, so it takes exactly one page.
+    const ONE_PAGE_ENTRY_VALUE_SIZE: usize = 3 * KB;
 
     #[test_log::test]
     fn test_blob_index_serde() {
@@ -532,13 +556,22 @@ mod tests {
         let mut buffer = Buffer::new(IoSliceMut::new(BATCH_SIZE), MAX_ENTRY_SIZE, Arc::new(Metrics::noop()));
 
         // 4K
-        assert!(buffer.push(&1u64, &vec![1u8; 3 * KB], 1, Compression::None, 1));
+        assert_eq!(
+            buffer.push(&1u64, &vec![1u8; 3 * KB], 1, Compression::None, 1),
+            Push::Ok
+        );
 
         // 16K (deny)
-        assert!(!buffer.push(&2u64, &vec![2u8; 13 * KB], 2, Compression::None, 2));
+        assert_eq!(
+            buffer.push(&2u64, &vec![2u8; 13 * KB], 2, Compression::None, 2),
+            Push::Unstorable
+        );
 
         // 4K
-        assert!(buffer.push(&3u64, &vec![3u8; 3 * KB], 3, Compression::None, 3));
+        assert_eq!(
+            buffer.push(&3u64, &vec![3u8; 3 * KB], 3, Compression::None, 3),
+            Push::Ok
+        );
 
         let (buf, infos) = buffer.finish();
         let buf = buf.into_io_slice();
@@ -578,13 +611,22 @@ mod tests {
         let mut buffer = Buffer::new(IoSliceMut::new(BATCH_SIZE), MAX_ENTRY_SIZE, Arc::new(Metrics::noop()));
 
         // 4K, block split
-        assert!(buffer.push(&4u64, &vec![4u8; 3 * KB], 4, Compression::None, 4));
+        assert_eq!(
+            buffer.push(&4u64, &vec![4u8; 3 * KB], 4, Compression::None, 4),
+            Push::Ok
+        );
 
         // 8K
-        assert!(buffer.push(&5u64, &vec![5u8; 7 * KB], 5, Compression::None, 5));
+        assert_eq!(
+            buffer.push(&5u64, &vec![5u8; 7 * KB], 5, Compression::None, 5),
+            Push::Ok
+        );
 
         // 8K, block early split
-        assert!(buffer.push(&6u64, &vec![6u8; 7 * KB], 6, Compression::None, 6));
+        assert_eq!(
+            buffer.push(&6u64, &vec![6u8; 7 * KB], 6, Compression::None, 6),
+            Push::Ok
+        );
 
         let (buf, infos) = buffer.finish();
         let buf = buf.into_io_slice();
@@ -646,7 +688,10 @@ mod tests {
         let mut buffer = Buffer::new(IoSliceMut::new(BATCH_SIZE), MAX_ENTRY_SIZE, Arc::new(Metrics::noop()));
 
         // 8K, block split
-        assert!(buffer.push(&7u64, &vec![7u8; 7 * KB], 7, Compression::None, 7));
+        assert_eq!(
+            buffer.push(&7u64, &vec![7u8; 7 * KB], 7, Compression::None, 7),
+            Push::Ok
+        );
 
         let (buf, infos) = buffer.finish();
         let buf = buf.into_io_slice();
@@ -675,6 +720,85 @@ mod tests {
                 ]
             }
         );
+    }
+
+    #[test_log::test]
+    fn test_push_no_space_or_unstorable() {
+        const BLOCK_SIZE: usize = 16 * KB;
+        const BLOB_INDEX_SIZE: usize = 4 * KB;
+        const MAX_ENTRY_SIZE: usize = BLOCK_SIZE - BLOB_INDEX_SIZE;
+        const BUFFER_SIZE: usize = 16 * KB;
+
+        let buffer = || Buffer::new(IoSliceMut::new(BUFFER_SIZE), MAX_ENTRY_SIZE, Arc::new(Metrics::noop()));
+        let fill = |buffer: &mut Buffer, count: u64| {
+            for i in 0..count {
+                assert_eq!(
+                    buffer.push(&i, &vec![i as u8; ONE_PAGE_ENTRY_VALUE_SIZE], i, Compression::None, i),
+                    Push::Ok
+                );
+            }
+        };
+
+        // 1. The tail of the buffer cannot even hold an entry header.
+        let mut b = buffer();
+        fill(&mut b, (BUFFER_SIZE / PAGE) as _);
+        assert_eq!(
+            b.push(
+                &42u64,
+                &vec![42u8; ONE_PAGE_ENTRY_VALUE_SIZE],
+                42,
+                Compression::None,
+                42
+            ),
+            Push::NoSpace
+        );
+
+        // 2. The tail of the buffer holds an entry header, but not the serialized entry.
+        let mut b = buffer();
+        fill(&mut b, (BUFFER_SIZE / PAGE - 1) as _);
+        assert_eq!(
+            b.push(&42u64, &vec![42u8; 8 * KB], 42, Compression::None, 42),
+            Push::NoSpace
+        );
+
+        // 3. The entry is larger than the max entry size, it can never be stored.
+        let mut b = buffer();
+        assert_eq!(
+            b.push(&42u64, &vec![42u8; MAX_ENTRY_SIZE], 42, Compression::None, 42),
+            Push::Unstorable
+        );
+
+        // 4. The entry fits the max entry size, but is larger than the whole buffer.
+        //
+        // NOTE: The max entry size and the buffer size are configured separately, so an entry can be within the max
+        // entry size and still never fit a buffer. `NoSpace` against an empty buffer is the only signal for it.
+        let mut b = Buffer::new(IoSliceMut::new(8 * KB), MAX_ENTRY_SIZE, Arc::new(Metrics::noop()));
+        assert!(b.is_empty());
+        assert_eq!(
+            b.push(&42u64, &vec![42u8; 8 * KB], 42, Compression::None, 42),
+            Push::NoSpace
+        );
+        assert!(b.is_empty());
+    }
+
+    #[test_log::test]
+    fn test_push_slice_no_space_or_unstorable() {
+        const BLOCK_SIZE: usize = 16 * KB;
+        const BLOB_INDEX_SIZE: usize = 4 * KB;
+        const MAX_ENTRY_SIZE: usize = BLOCK_SIZE - BLOB_INDEX_SIZE;
+        const BUFFER_SIZE: usize = 16 * KB;
+
+        let mut b = Buffer::new(IoSliceMut::new(BUFFER_SIZE), MAX_ENTRY_SIZE, Arc::new(Metrics::noop()));
+
+        // The entry is larger than the max entry size, it can never be stored.
+        assert_eq!(b.push_slice(&vec![1u8; MAX_ENTRY_SIZE + 1], 1, 1), Push::Unstorable);
+
+        // Fill the buffer up.
+        assert_eq!(b.push_slice(&vec![2u8; PAGE], 2, 2), Push::Ok);
+        assert_eq!(b.push_slice(&vec![3u8; MAX_ENTRY_SIZE], 3, 3), Push::Ok);
+
+        // The entry fits the max entry size, but doesn't fit the tail of the buffer.
+        assert_eq!(b.push_slice(&vec![4u8; PAGE], 4, 4), Push::NoSpace);
     }
 
     #[test_log::test]

--- a/foyer-storage/src/engine/block/flusher.rs
+++ b/foyer-storage/src/engine/block/flusher.rs
@@ -48,7 +48,7 @@ use crate::test_utils::*;
 use crate::{
     Compression,
     engine::block::{
-        buffer::{Batch, BlobPart, Block, Buffer, SplitCtx, Splitter},
+        buffer::{Batch, BlobPart, Block, Buffer, Push, SplitCtx, Splitter},
         indexer::{EntryAddress, HashedEntryAddress, Indexer},
         manager::{BlockId, BlockManager, GetCleanBlockHandle},
         reclaimer::Reinsertion,
@@ -206,6 +206,7 @@ where
             rx: Some(rx),
             buffer,
             ctx,
+            pending: VecDeque::new(),
             tombstone_infos: vec![],
             waiters: vec![],
             piece_refs: vec![],
@@ -295,6 +296,11 @@ where
     // NOTE: writer is always `Some(..)`.
     buffer: Option<Buffer>,
     ctx: SplitCtx,
+    /// The submissions that are received but not handled yet.
+    ///
+    /// A submission that doesn't fit the remaining space of the current buffer is kept here and retried after the
+    /// buffer rotates. The submissions received after it are kept here, too, to preserve the submission order.
+    pending: VecDeque<Submission<K, V, P>>,
     tombstone_infos: Vec<TombstoneInfo>,
     piece_refs: Vec<PieceRef<K, V, P>>,
     waiters: Vec<oneshot::Sender<()>>,
@@ -349,17 +355,22 @@ where
 
         loop {
             while let Ok(submission) = rx.try_recv() {
-                self.recv(submission);
+                self.pending.push_back(submission);
             }
+            self.handle_pending();
 
             #[cfg(not(any(test, feature = "test_utils")))]
             let can_flush = true;
             #[cfg(any(test, feature = "test_utils"))]
             let can_flush = !self.flush_switch.is_on();
 
+            // NOTE: A pending submission always implies a non-empty buffer, for a submission that is rejected by an
+            // empty buffer is dropped instead of pending. It is listed here anyway to make sure that a pending
+            // submission always triggers the rotation that it is waiting for.
             let need_flush = !self.buffer.as_ref().unwrap().is_empty()
                 || !self.waiters.is_empty()
-                || !self.tombstone_infos.is_empty();
+                || !self.tombstone_infos.is_empty()
+                || !self.pending.is_empty();
             let no_io_task = self.io_tasks.is_empty();
 
             if can_flush && need_flush && no_io_task {
@@ -384,6 +395,9 @@ where
                 let io_buffer = self.rotate_buffer.take().unwrap();
                 let buffer = Buffer::new(io_buffer, self.max_entry_size, self.metrics.clone());
                 self.buffer = Some(buffer);
+
+                // Feed the submissions that the sealed buffer cannot hold into the rotated buffer.
+                self.handle_pending();
             }
 
             tokio::select! {
@@ -397,7 +411,7 @@ where
                     self.rotate_buffer = io_slice.try_into_io_slice_mut();
                 }
                 Ok(submission) = rx.recv() => {
-                    self.recv(submission);
+                    self.pending.push_back(submission);
                 }
                 // Graceful shutdown.
                 else => break,
@@ -406,7 +420,21 @@ where
         Ok(())
     }
 
-    fn recv(&mut self, submission: Submission<K, V, P>) {
+    /// Handle the pending submissions in order, until the current buffer cannot hold the next one.
+    fn handle_pending(&mut self) {
+        while let Some(submission) = self.pending.pop_front() {
+            if let Some(submission) = self.recv(submission) {
+                self.pending.push_front(submission);
+                break;
+            }
+        }
+    }
+
+    /// Handle a submission.
+    ///
+    /// Returns the submission back if the current buffer cannot hold it, in which case it must be retried after the
+    /// buffer rotates.
+    fn recv(&mut self, submission: Submission<K, V, P>) -> Option<Submission<K, V, P>> {
         tracing::trace!(
             id = self.id,
             ?submission,
@@ -417,29 +445,46 @@ where
             self.queue_init = Some(Instant::now());
         }
 
-        let report = |written: bool| {
-            if !written {
-                self.metrics.storage_queue_buffer_overflow.increase(1);
-            }
-        };
-
         match submission {
             Submission::CacheEntry {
                 piece,
                 estimated_size,
                 sequence,
             } => {
-                let enqueued = self.buffer.as_mut().unwrap().push(
-                    piece.key(),
-                    piece.value(),
-                    piece.hash(),
-                    self.compression,
-                    sequence,
-                );
-                if enqueued {
-                    self.piece_refs.push(piece);
+                let buffer = self.buffer.as_mut().unwrap();
+                let push = buffer.push(piece.key(), piece.value(), piece.hash(), self.compression, sequence);
+                // NOTE: The push doesn't modify the buffer if it doesn't succeed, so this tells if the entry was
+                // rejected by an empty buffer.
+                let rejected_by_empty_buffer = buffer.is_empty();
+
+                match push {
+                    Push::Ok => self.piece_refs.push(piece),
+                    // The entry doesn't fit the tail of the current buffer, retry it after the buffer rotates.
+                    Push::NoSpace if !rejected_by_empty_buffer => {
+                        tracing::trace!(
+                            id = self.id,
+                            hash = piece.hash(),
+                            "[block engine flush runner]: defer entry to the next buffer"
+                        );
+                        return Some(Submission::CacheEntry {
+                            piece,
+                            estimated_size,
+                            sequence,
+                        });
+                    }
+                    // The entry is rejected by an empty buffer or by the max entry size, it can never be stored.
+                    Push::NoSpace | Push::Unstorable => {
+                        tracing::warn!(
+                            id = self.id,
+                            hash = piece.hash(),
+                            "[block engine flush runner]: entry is too large to be stored, drop it"
+                        );
+                        self.metrics.storage_queue_buffer_overflow.increase(1);
+                    }
                 }
-                report(enqueued);
+
+                // NOTE: The submit queue size must be decreased exactly once per submission, so it is only decreased
+                // after the submission is handled, never after a deferred push attempt.
                 self.submit_queue_size.fetch_sub(estimated_size, Ordering::Relaxed);
             }
 
@@ -447,15 +492,43 @@ where
             Submission::Reinsertion { reinsertion } => {
                 // Skip reinsertion if the entry is not in the indexer.
                 if self.indexer.get(reinsertion.hash).is_some() {
-                    report(self.buffer.as_mut().unwrap().push_slice(
+                    let buffer = self.buffer.as_mut().unwrap();
+                    let push = buffer.push_slice(
                         &reinsertion.slice[..reinsertion.len],
                         reinsertion.hash,
                         reinsertion.sequence,
-                    ));
+                    );
+                    let rejected_by_empty_buffer = buffer.is_empty();
+
+                    match push {
+                        Push::Ok => {}
+                        // The reinsertion doesn't fit the tail of the current buffer, retry it after the buffer
+                        // rotates.
+                        Push::NoSpace if !rejected_by_empty_buffer => {
+                            tracing::trace!(
+                                id = self.id,
+                                hash = reinsertion.hash,
+                                "[block engine flush runner]: defer reinsertion to the next buffer"
+                            );
+                            return Some(Submission::Reinsertion { reinsertion });
+                        }
+                        // The reinsertion is rejected by an empty buffer or by the max entry size, it can never be
+                        // stored.
+                        Push::NoSpace | Push::Unstorable => {
+                            tracing::warn!(
+                                id = self.id,
+                                hash = reinsertion.hash,
+                                "[block engine flush runner]: reinsertion is too large to be stored, drop it"
+                            );
+                            self.metrics.storage_queue_buffer_overflow.increase(1);
+                        }
+                    }
                 }
             }
             Submission::Wait { tx } => self.waiters.push(tx),
         }
+
+        None
     }
 
     fn submit_io_task(
@@ -678,5 +751,463 @@ where
         self.metrics
             .storage_queue_rotate_duration
             .record(init.elapsed().as_secs_f64());
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::{borrow::Cow, collections::HashMap, path::Path, sync::atomic::AtomicU64, time::Duration};
+
+    use foyer_common::hasher::ModHasher;
+    use foyer_memory::{Cache, CacheBuilder, CacheEntry, FifoConfig, TestProperties};
+    use mixtrics::metrics::{
+        BoxedCounter, BoxedCounterVec, BoxedGauge, BoxedGaugeVec, BoxedHistogram, BoxedHistogramVec, BoxedRegistry,
+        CounterOps, CounterVecOps, GaugeOps, GaugeVecOps, HistogramOps, HistogramVecOps, RegistryOps,
+    };
+    use parking_lot::Mutex;
+
+    use super::*;
+    use crate::{
+        PsyncIoEngineConfig, RejectAll, StorageFilter,
+        engine::block::{
+            eviction::FifoPicker,
+            reclaimer::{Reclaimer, ReclaimerTrait},
+        },
+        io::{
+            device::{DeviceBuilder, fs::FsDeviceBuilder},
+            engine::{IoEngineBuildContext, IoEngineConfig},
+        },
+        serde::EntrySerializer,
+    };
+
+    const KB: usize = 1024;
+    /// A 3 KiB entry is serialized into a bit more than 3 KiB, so it takes exactly one page.
+    const ONE_PAGE_ENTRY_VALUE_SIZE: usize = 3 * KB;
+
+    /* metrics registry that counts the counter increments, so that the tests can assert on them */
+
+    #[derive(Debug, Default, Clone)]
+    struct TestCounters {
+        counters: Arc<Mutex<HashMap<String, Arc<AtomicU64>>>>,
+    }
+
+    impl TestCounters {
+        fn key(name: &str, labels: &[&str]) -> String {
+            format!("{name}{{{}}}", labels.join(","))
+        }
+
+        fn counter(&self, key: String) -> Arc<AtomicU64> {
+            self.counters.lock().entry(key).or_default().clone()
+        }
+
+        fn get(&self, name: &str, labels: &[&str]) -> u64 {
+            self.counter(Self::key(name, labels)).load(Ordering::Relaxed)
+        }
+    }
+
+    #[derive(Debug)]
+    struct TestCounter(Arc<AtomicU64>);
+
+    impl CounterOps for TestCounter {
+        fn increase(&self, val: u64) {
+            self.0.fetch_add(val, Ordering::Relaxed);
+        }
+    }
+
+    #[derive(Debug)]
+    struct TestCounterVec {
+        name: String,
+        counters: TestCounters,
+    }
+
+    impl CounterVecOps for TestCounterVec {
+        fn counter(&self, labels: &[Cow<'static, str>]) -> BoxedCounter {
+            let labels = labels.iter().map(|label| label.as_ref()).collect_vec();
+            Box::new(TestCounter(
+                self.counters.counter(TestCounters::key(&self.name, &labels)),
+            ))
+        }
+    }
+
+    /// Only the counters are recorded, the other metrics are ignored.
+    #[derive(Debug)]
+    struct TestIgnored;
+
+    impl GaugeOps for TestIgnored {
+        fn increase(&self, _: u64) {}
+
+        fn decrease(&self, _: u64) {}
+
+        fn absolute(&self, _: u64) {}
+    }
+
+    impl GaugeVecOps for TestIgnored {
+        fn gauge(&self, _: &[Cow<'static, str>]) -> BoxedGauge {
+            Box::new(TestIgnored)
+        }
+    }
+
+    impl HistogramOps for TestIgnored {
+        fn record(&self, _: f64) {}
+    }
+
+    impl HistogramVecOps for TestIgnored {
+        fn histogram(&self, _: &[Cow<'static, str>]) -> BoxedHistogram {
+            Box::new(TestIgnored)
+        }
+    }
+
+    #[derive(Debug)]
+    struct TestRegistry {
+        counters: TestCounters,
+    }
+
+    impl RegistryOps for TestRegistry {
+        fn register_counter_vec(
+            &self,
+            name: Cow<'static, str>,
+            _: Cow<'static, str>,
+            _: &'static [&'static str],
+        ) -> BoxedCounterVec {
+            Box::new(TestCounterVec {
+                name: name.into_owned(),
+                counters: self.counters.clone(),
+            })
+        }
+
+        fn register_gauge_vec(
+            &self,
+            _: Cow<'static, str>,
+            _: Cow<'static, str>,
+            _: &'static [&'static str],
+        ) -> BoxedGaugeVec {
+            Box::new(TestIgnored)
+        }
+
+        fn register_histogram_vec(
+            &self,
+            _: Cow<'static, str>,
+            _: Cow<'static, str>,
+            _: &'static [&'static str],
+        ) -> BoxedHistogramVec {
+            Box::new(TestIgnored)
+        }
+
+        fn register_histogram_vec_with_buckets(
+            &self,
+            _: Cow<'static, str>,
+            _: Cow<'static, str>,
+            _: &'static [&'static str],
+            _: Vec<f64>,
+        ) -> BoxedHistogramVec {
+            Box::new(TestIgnored)
+        }
+    }
+
+    /* test utils */
+
+    type TestCache = Cache<u64, Vec<u8>, ModHasher, TestProperties>;
+    type TestCacheEntry = CacheEntry<u64, Vec<u8>, ModHasher, TestProperties>;
+
+    fn cache_for_test() -> TestCache {
+        CacheBuilder::new(1024)
+            .with_shards(1)
+            .with_eviction_config(FifoConfig::default())
+            .with_hash_builder(ModHasher::default())
+            .build()
+    }
+
+    /// Push an entry into an empty buffer, to tell why the buffer rejects it.
+    fn push_into_empty_buffer(entry: &TestCacheEntry, io_buffer_size: usize, max_entry_size: usize) -> Push {
+        let mut buffer = Buffer::new(
+            IoSliceMut::new(io_buffer_size),
+            max_entry_size,
+            Arc::new(Metrics::noop()),
+        );
+        buffer.push(entry.key(), entry.value(), entry.hash(), Compression::None, 0)
+    }
+
+    /// Await `future`, but panic if it doesn't finish in time, so that a flusher that makes no progress fails the test
+    /// instead of hanging it.
+    async fn with_deadline<F>(future: F) -> F::Output
+    where
+        F: Future,
+    {
+        const DEADLINE: Duration = Duration::from_secs(60);
+
+        let start = Instant::now();
+        let mut future = std::pin::pin!(future);
+        poll_fn(move |cx| {
+            if let Poll::Ready(output) = future.as_mut().poll(cx) {
+                return Poll::Ready(output);
+            }
+            assert!(start.elapsed() < DEADLINE, "the future doesn't finish in {DEADLINE:?}");
+            // NOTE: Reschedule instead of sleeping, for `tokio::time` is not available in this crate.
+            cx.waker().wake_by_ref();
+            Poll::Pending
+        })
+        .await
+    }
+
+    /// A running flusher with everything it needs to write to a device on a temporary directory.
+    struct FlusherHarness {
+        flusher: Flusher<u64, Vec<u8>, TestProperties>,
+        indexer: Indexer,
+        submit_queue_size: Arc<AtomicUsize>,
+        counters: TestCounters,
+        flush_switch: Switch,
+        sequence: AtomicU64,
+    }
+
+    impl FlusherHarness {
+        /// Run a flusher on a device on the given directory.
+        ///
+        /// NOTE: The max entry size is `block_size - blob_index_size`, while the buffer capacity is `io_buffer_size`.
+        /// They are configured separately, just like [`crate::BlockEngineConfig`] does.
+        async fn open(dir: impl AsRef<Path>, block_size: usize, blob_index_size: usize, io_buffer_size: usize) -> Self {
+            /// Enough blocks to make sure that no reclamation interferes with the tests.
+            const CAPACITY: usize = 256 * KB;
+
+            let device = FsDeviceBuilder::new(dir).with_capacity(CAPACITY).build().unwrap();
+            let spawner = Spawner::current();
+            let io_engine = PsyncIoEngineConfig::new()
+                .boxed()
+                .build(IoEngineBuildContext {
+                    spawner: spawner.clone(),
+                })
+                .await
+                .unwrap();
+
+            let counters = TestCounters::default();
+            let registry: BoxedRegistry = Box::new(TestRegistry {
+                counters: counters.clone(),
+            });
+            let metrics = Arc::new(Metrics::new("test", &registry));
+
+            let indexer = Indexer::new(4);
+            let submit_queue_size = Arc::<AtomicUsize>::default();
+            let (flusher, rx) = Flusher::new(0, submit_queue_size.clone(), metrics.clone());
+
+            let reclaimer = Reclaimer::new(
+                indexer.clone(),
+                vec![flusher.clone()],
+                Arc::new(StorageFilter::new().with_condition(RejectAll)),
+                blob_index_size,
+                device.statistics().clone(),
+                spawner.clone(),
+            );
+            let block_manager = BlockManager::open(
+                device,
+                io_engine,
+                block_size,
+                vec![Box::<FifoPicker>::default()],
+                Arc::new(reclaimer) as Arc<dyn ReclaimerTrait>,
+                1,
+                1,
+                metrics.clone(),
+                spawner.clone(),
+            )
+            .unwrap();
+            // There is nothing to recover from a device on a temporary directory, all blocks are clean.
+            block_manager.init(&(0..block_manager.blocks() as BlockId).collect_vec());
+
+            let flush_switch = Switch::default();
+            flusher
+                .run(
+                    rx,
+                    block_size,
+                    io_buffer_size,
+                    blob_index_size,
+                    Compression::None,
+                    indexer.clone(),
+                    block_manager,
+                    None,
+                    metrics,
+                    &spawner,
+                    flush_switch.clone(),
+                )
+                .unwrap();
+
+            Self {
+                flusher,
+                indexer,
+                submit_queue_size,
+                counters,
+                flush_switch,
+                sequence: AtomicU64::new(0),
+            }
+        }
+
+        fn enqueue(&self, entry: &TestCacheEntry) {
+            let estimated_size = EntrySerializer::estimated_size(entry.key(), entry.value());
+            self.flusher.submit(Submission::CacheEntry {
+                piece: entry.piece().into(),
+                estimated_size,
+                sequence: self.sequence.fetch_add(1, Ordering::Relaxed),
+            });
+        }
+
+        /// The count of the entries that are dropped for they can never be stored.
+        fn buffer_overflow(&self) -> u64 {
+            self.counters
+                .get("foyer_storage_inner_op_total", &["test", "buffer_overflow"])
+        }
+
+        fn submit_queue_size(&self) -> usize {
+            self.submit_queue_size.load(Ordering::Relaxed)
+        }
+    }
+
+    /// An entry that doesn't fit the tail of the current buffer must be deferred to the next buffer, not dropped.
+    #[test_log::test(tokio::test)]
+    async fn test_defer_entry_that_does_not_fit_buffer_tail() {
+        const BLOCK_SIZE: usize = 16 * KB;
+        const BLOB_INDEX_SIZE: usize = 4 * KB;
+        const IO_BUFFER_SIZE: usize = 16 * KB;
+        const ENTRIES_PER_BUFFER: u64 = (IO_BUFFER_SIZE / PAGE) as _;
+        /// Fill more than one buffer, so that the entries have to be deferred more than once.
+        const ENTRIES: u64 = ENTRIES_PER_BUFFER * 3;
+
+        let dir = tempfile::tempdir().unwrap();
+        let harness = FlusherHarness::open(dir.path(), BLOCK_SIZE, BLOB_INDEX_SIZE, IO_BUFFER_SIZE).await;
+        let memory = cache_for_test();
+
+        let entries = (0..ENTRIES)
+            .map(|i| memory.insert(i, vec![i as u8; ONE_PAGE_ENTRY_VALUE_SIZE]))
+            .collect_vec();
+
+        // Hold the flush, so that the buffer cannot rotate while the entries are submitted. The buffer is filled up by
+        // the first `ENTRIES_PER_BUFFER` entries, and all the entries after them find no space in the buffer tail.
+        harness.flush_switch.on();
+        for entry in &entries {
+            harness.enqueue(entry);
+        }
+        harness.flush_switch.off();
+        with_deadline(harness.flusher.wait()).await;
+
+        // 1. No entry is silently dropped.
+        let addrs = (0..ENTRIES)
+            .map(|i| (i, harness.indexer.get(memory.hash(&i))))
+            .collect_vec();
+        let lost = addrs
+            .iter()
+            .filter(|(_, addr)| addr.is_none())
+            .map(|(i, _)| *i)
+            .collect_vec();
+        assert!(lost.is_empty(), "entries {lost:?} are dropped");
+
+        // 2. The submission order is preserved.
+        let addrs = addrs.into_iter().map(|(_, addr)| addr.unwrap()).collect_vec();
+        assert!(
+            addrs
+                .windows(2)
+                .all(|w| (w[0].block, w[0].offset) < (w[1].block, w[1].offset)),
+            "entries are written out of the submission order: {addrs:?}"
+        );
+
+        // 3. A deferred entry is not an overflow, and the submit queue size is decreased exactly once per submission.
+        assert_eq!(harness.buffer_overflow(), 0);
+        assert_eq!(harness.submit_queue_size(), 0);
+    }
+
+    /// An entry that is larger than the max entry size can never be stored, it must be dropped and counted.
+    #[test_log::test(tokio::test)]
+    async fn test_drop_entry_larger_than_max_entry_size() {
+        const BLOCK_SIZE: usize = 16 * KB;
+        const BLOB_INDEX_SIZE: usize = 4 * KB;
+        const MAX_ENTRY_SIZE: usize = BLOCK_SIZE - BLOB_INDEX_SIZE;
+        const IO_BUFFER_SIZE: usize = 16 * KB;
+
+        let dir = tempfile::tempdir().unwrap();
+        let harness = FlusherHarness::open(dir.path(), BLOCK_SIZE, BLOB_INDEX_SIZE, IO_BUFFER_SIZE).await;
+        let memory = cache_for_test();
+
+        // The entry fits the buffer, but its aligned size exceeds the max entry size.
+        let large = memory.insert(0, vec![0u8; MAX_ENTRY_SIZE]);
+        let small = memory.insert(1, vec![1u8; ONE_PAGE_ENTRY_VALUE_SIZE]);
+        assert_eq!(
+            push_into_empty_buffer(&large, IO_BUFFER_SIZE, MAX_ENTRY_SIZE),
+            Push::Unstorable
+        );
+
+        harness.enqueue(&large);
+        harness.enqueue(&small);
+        with_deadline(harness.flusher.wait()).await;
+
+        assert!(harness.indexer.get(memory.hash(&0)).is_none());
+        assert!(harness.indexer.get(memory.hash(&1)).is_some());
+        assert_eq!(harness.buffer_overflow(), 1);
+        assert_eq!(harness.submit_queue_size(), 0);
+    }
+
+    /// An entry that fits the max entry size but is larger than the whole buffer can never be stored, either. It must
+    /// be dropped instead of being deferred forever.
+    #[test_log::test(tokio::test)]
+    async fn test_drop_entry_larger_than_buffer() {
+        const BLOCK_SIZE: usize = 16 * KB;
+        const BLOB_INDEX_SIZE: usize = 4 * KB;
+        const MAX_ENTRY_SIZE: usize = BLOCK_SIZE - BLOB_INDEX_SIZE;
+        // NOTE: The buffer is smaller than the max entry size, for they are configured separately.
+        const IO_BUFFER_SIZE: usize = 8 * KB;
+
+        let dir = tempfile::tempdir().unwrap();
+        let harness = FlusherHarness::open(dir.path(), BLOCK_SIZE, BLOB_INDEX_SIZE, IO_BUFFER_SIZE).await;
+        let memory = cache_for_test();
+
+        // The entry fits the max entry size, but it is larger than an empty buffer. `NoSpace` against an empty buffer
+        // is the only signal that the entry can never be stored.
+        let large = memory.insert(0, vec![0u8; IO_BUFFER_SIZE]);
+        let small = memory.insert(1, vec![1u8; ONE_PAGE_ENTRY_VALUE_SIZE]);
+        assert_eq!(
+            push_into_empty_buffer(&large, IO_BUFFER_SIZE, MAX_ENTRY_SIZE),
+            Push::NoSpace
+        );
+
+        harness.enqueue(&large);
+        harness.enqueue(&small);
+        // The deadline turns an endless defer-and-retry loop into a failure instead of a hang.
+        with_deadline(harness.flusher.wait()).await;
+
+        assert!(harness.indexer.get(memory.hash(&0)).is_none());
+        assert!(harness.indexer.get(memory.hash(&1)).is_some());
+        assert_eq!(harness.buffer_overflow(), 1);
+        assert_eq!(harness.submit_queue_size(), 0);
+    }
+
+    /// The submit queue size must be decreased exactly once per submission, no matter if the entry is written, deferred
+    /// and written, or dropped.
+    #[test_log::test(tokio::test)]
+    async fn test_submit_queue_size_accounting() {
+        const BLOCK_SIZE: usize = 16 * KB;
+        const BLOB_INDEX_SIZE: usize = 4 * KB;
+        const MAX_ENTRY_SIZE: usize = BLOCK_SIZE - BLOB_INDEX_SIZE;
+        const IO_BUFFER_SIZE: usize = 16 * KB;
+        const ENTRIES_PER_BUFFER: u64 = (IO_BUFFER_SIZE / PAGE) as _;
+
+        let dir = tempfile::tempdir().unwrap();
+        let harness = FlusherHarness::open(dir.path(), BLOCK_SIZE, BLOB_INDEX_SIZE, IO_BUFFER_SIZE).await;
+        let memory = cache_for_test();
+
+        // Written directly, deferred then written, and dropped, all in one batch.
+        let entries = (0..ENTRIES_PER_BUFFER * 2)
+            .map(|i| memory.insert(i, vec![i as u8; ONE_PAGE_ENTRY_VALUE_SIZE]))
+            .collect_vec();
+        let unstorable = memory.insert(ENTRIES_PER_BUFFER * 2, vec![0u8; MAX_ENTRY_SIZE]);
+
+        harness.flush_switch.on();
+        for entry in &entries {
+            harness.enqueue(entry);
+        }
+        harness.enqueue(&unstorable);
+        harness.flush_switch.off();
+        with_deadline(harness.flusher.wait()).await;
+
+        // A double decrease underflows the counter, a missing decrease leaves it positive.
+        assert_eq!(harness.submit_queue_size(), 0);
+        assert_eq!(harness.buffer_overflow(), 1);
+        for i in 0..ENTRIES_PER_BUFFER * 2 {
+            assert!(harness.indexer.get(memory.hash(&i)).is_some(), "entry {i} is dropped");
+        }
+        assert!(harness.indexer.get(memory.hash(&(ENTRIES_PER_BUFFER * 2))).is_none());
     }
 }


### PR DESCRIPTION
Closes #1334.

Cache entries that don't fit the *remaining* space of the current flush buffer were dropped instead of written into the next buffer, and dropping the `PieceRef` also evicted them from the `Keeper`. Since rotation is gated on `no_io_task`, this silently lost the tail of every write burst.

- `Buffer::push` / `push_slice` return `Push { Ok, NoSpace, Unstorable }` instead of `bool`.
- The flush runner keeps a pending queue: a `NoSpace` submission is retried after the buffer rotates, and later submissions queue behind it so a `Submission::Wait` can't overtake a deferred entry and let `Flusher::wait()` return too early.
- `NoSpace` from an already-empty buffer means the entry can never fit, so it's dropped and counted there — retries stay bounded.
- `storage_queue_buffer_overflow` now counts only entries that can never be stored.

Tests cover a deferred entry persisted in submission order, an entry over `max_entry_size` dropped, an entry larger than an empty buffer dropped rather than retried forever, and balanced `submit_queue_size` accounting.