### PR TITLE
fix(storage): make may_contains keeper-aware for in-flight entries

### DIFF
--- a/foyer-storage/src/keeper.rs
+++ b/foyer-storage/src/keeper.rs
@@ -87,6 +87,16 @@ where
         shard.find(hash, |p| key.equivalent(p.key())).cloned()
     }
 
+    /// Check if the keeper holds a piece with the given key without cloning it.
+    pub fn contains<Q>(&self, hash: u64, key: &Q) -> bool
+    where
+        Q: Hash + equivalent::Equivalent<K> + ?Sized,
+    {
+        let shard = self.shard(hash);
+        let shard = shard.read();
+        shard.find(hash, |p| key.equivalent(p.key())).is_some()
+    }
+
     fn shard(&self, hash: u64) -> Arc<RwLock<Shard<K, V, P>>> {
         let index = (hash as usize) % self.inner.shards.len();
         self.inner.shards[index].clone()

--- a/foyer-storage/src/store.rs
+++ b/foyer-storage/src/store.rs
@@ -261,13 +261,17 @@ where
 
     /// Check if the disk cache contains a cached entry with the given key.
     ///
-    /// `contains` may return a false-positive result if there is a hash collision with the given key.
+    /// Besides the entries that are already written to the device, `may_contains` may also return `true` for an entry
+    /// that was recently enqueued but not yet flushed, which [`Store::load`] can still serve from the keeper. Whether
+    /// such an in-flight entry is reported is not guaranteed.
+    ///
+    /// `may_contains` may return a false-positive result if there is a hash collision with the given key.
     pub fn may_contains<Q>(&self, key: &Q) -> bool
     where
         Q: Hash + Equivalent<K> + ?Sized,
     {
         let hash = self.inner.hasher.hash_one(key);
-        self.inner.engine.may_contains(hash)
+        self.inner.keeper.contains(hash, key) || self.inner.engine.may_contains(hash)
     }
 
     /// Delete all cached entries of the disk cache.
@@ -582,6 +586,97 @@ mod tests {
         assert!(matches!(l1, Load::Miss));
         assert!(matches!(l2, Load::Entry { .. }));
         assert_eq!(l2.entry().unwrap().1, "bar");
+    }
+
+    #[tokio::test]
+    async fn test_may_contains_in_flight_entry() {
+        let dir = tempfile::tempdir().unwrap();
+        let metrics = Arc::new(Metrics::noop());
+        let memory: Cache<u64, Vec<u8>> = CacheBuilder::new(10).build();
+
+        // Hold the flusher so that the enqueued entry stays in the keeper and never reaches the device.
+        let flush_switch = Switch::default();
+        flush_switch.on();
+
+        let store = StoreBuilder::new("test", memory.clone(), metrics)
+            .with_io_engine_config(PsyncIoEngineConfig::new())
+            .with_engine_config(
+                BlockEngineConfig::new(
+                    FsDeviceBuilder::new(dir.path())
+                        .with_capacity(4 * 1024 * 1024)
+                        .build()
+                        .unwrap(),
+                )
+                .with_block_size(16 * 1024)
+                .with_flush_switch(flush_switch.clone()),
+            )
+            .build()
+            .await
+            .unwrap();
+
+        let e1 = memory.insert(1, b"v1".to_vec());
+        store.enqueue(e1.piece(), true);
+
+        // The entry is in-flight: `load` serves it from the keeper, so `may_contains` must agree.
+        let l1 = store.load(&1).await.unwrap();
+        assert!(matches!(l1, Load::Piece { .. }));
+        assert!(store.may_contains(&1));
+        assert!(!store.may_contains(&2));
+
+        // Let the flusher write the entry to the device.
+        flush_switch.off();
+        store.wait().await;
+
+        let l1 = store.load(&1).await.unwrap();
+        assert!(matches!(l1, Load::Entry { ref value, .. } if value == b"v1"));
+        assert!(store.may_contains(&1));
+        assert!(!store.may_contains(&2));
+    }
+
+    /// `delete` writes a tombstone to the engine indexer, but it does not evict the keeper. So an entry that is deleted
+    /// while still in-flight keeps being served by `load`, and `may_contains` reports it accordingly.
+    #[tokio::test]
+    async fn test_may_contains_in_flight_entry_after_delete() {
+        let dir = tempfile::tempdir().unwrap();
+        let metrics = Arc::new(Metrics::noop());
+        let memory: Cache<u64, Vec<u8>> = CacheBuilder::new(10).build();
+
+        // Hold the flusher so that the enqueued entry stays in the keeper and never reaches the device.
+        let flush_switch = Switch::default();
+        flush_switch.on();
+
+        let store = StoreBuilder::new("test", memory.clone(), metrics)
+            .with_io_engine_config(PsyncIoEngineConfig::new())
+            .with_engine_config(
+                BlockEngineConfig::new(
+                    FsDeviceBuilder::new(dir.path())
+                        .with_capacity(4 * 1024 * 1024)
+                        .build()
+                        .unwrap(),
+                )
+                .with_block_size(16 * 1024)
+                .with_flush_switch(flush_switch.clone()),
+            )
+            .build()
+            .await
+            .unwrap();
+
+        let e1 = memory.insert(1, b"v1".to_vec());
+        store.enqueue(e1.piece(), true);
+        store.delete(&1);
+
+        // The keeper still holds the in-flight entry, so `load` still serves it and `may_contains` agrees.
+        let l1 = store.load(&1).await.unwrap();
+        assert!(matches!(l1, Load::Piece { .. }));
+        assert!(store.may_contains(&1));
+
+        // Once the flush finishes, the keeper releases the entry and the tombstone takes effect.
+        flush_switch.off();
+        store.wait().await;
+
+        let l1 = store.load(&1).await.unwrap();
+        assert!(matches!(l1, Load::Miss));
+        assert!(!store.may_contains(&1));
     }
 
     #[tokio::test]

--- a/foyer/src/hybrid/cache.rs
+++ b/foyer/src/hybrid/cache.rs
@@ -597,6 +597,10 @@ where
 
     /// Check if the hybrid cache contains a cached entry with the given key.
     ///
+    /// `contains` covers the in-memory cache and the disk cache. Besides the disk cache entries that are already
+    /// written to the device, `contains` may also return `true` for an entry that was recently enqueued to the disk
+    /// cache but not yet flushed. Whether such an in-flight entry is reported is not guaranteed.
+    ///
     /// `contains` may return a false-positive result if there is a hash collision with the given key.
     pub fn contains<Q>(&self, key: &Q) -> bool
     where
@@ -1601,6 +1605,40 @@ mod tests {
             .unwrap();
         assert_eq!(e5.source(), Source::Disk);
         drop(e5);
+    }
+
+    #[test_log::test(tokio::test)]
+    async fn test_hybrid_cache_contains_in_flight_entry() {
+        let dir = tempfile::tempdir().unwrap();
+
+        let flush_switch = Switch::default();
+
+        let hybrid = open_with(
+            dir.path(),
+            |b| b.with_policy(HybridCachePolicy::WriteOnInsertion),
+            |b| b.with_flush_switch(flush_switch.clone()),
+        )
+        .await;
+
+        // Hold the flusher, so that the inserted entry stays in the disk cache write queue.
+        flush_switch.on();
+
+        drop(hybrid.insert(1, vec![1; 7 * KB]));
+        // Drop the in-memory copy, so that only the disk cache can answer for the entry.
+        hybrid.memory().remove(&1);
+        assert!(!hybrid.memory().contains(&1));
+
+        // The entry is in-flight but still retrievable, so `contains` must report it.
+        assert!(hybrid.contains(&1));
+        assert_eq!(hybrid.get(&1).await.unwrap().unwrap().value(), &vec![1; 7 * KB]);
+
+        // Let the flusher write the entry to the device.
+        flush_switch.off();
+        hybrid.storage().wait().await;
+
+        hybrid.memory().remove(&1);
+        assert!(hybrid.contains(&1));
+        assert!(!hybrid.contains(&2));
     }
 
     #[test_log::test(tokio::test)]


### PR DESCRIPTION
Closes #1336.

`Store::may_contains` only probed the engine indexer, which is populated after the flusher writes an entry to the device. `Store::load` checks the keeper first, so an enqueued-but-unflushed entry was retrievable via `get` while `contains` reported `false` — a false negative the docs never promised.

This makes `may_contains` consult the keeper as `load` does:

```rust
self.inner.keeper.contains(hash, key) || self.inner.engine.may_contains(hash)
```

- Adds a non-cloning `Keeper::contains` (`Keeper::get` returns `Option<Piece<..>>` and would clone a `Piece` just to produce a bool). Cost is one sharded read lock on the miss path, which `load` already pays. It matches on key equivalence, not hash alone, so it adds no new false-positive source.
- Updates the `contains` / `may_contains` docs to say an in-flight entry *may* be reported. It cannot be guaranteed: `PieceRef::drop` removes the keeper occupant by `(hash, key)` rather than by identity, and `Keeper::insert` overwrites on duplicate keys, so re-enqueueing a key can let an older drop evict the newer occupant. This does not reintroduce the inconsistency — `load` reads the same keeper, so both fall through to the engine together.
- Every path that abandons a piece drops its `PieceRef`, which evicts the keeper, so `contains` returns to `false` in lockstep with `load`: the `enqueue` early returns (`Age::Young` skip, submit-queue overflow, `!active`), the flusher's `Buffer::push` overflow, and io errors. On success `indexer.insert_batch` runs before `piece_refs` are dropped, so the keeper→indexer handoff is monotonic — no instant where both report `false`.