### PR TITLE
fix(memory): preserve LRU invariants when reinserting records

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,6 +26,7 @@ exclude = ["website/*"]
 [workspace.dependencies]
 allocator-api2 = "0.2"
 anyhow = "1"
+asyncband = "0.6.7"
 bincode = "1"
 bitflags = "2"
 bytes = "1"
@@ -61,7 +62,6 @@ itertools = { version = "0.15.0" }
 jiff = { version = "0.2.16" }
 libc = "0.2"
 lz4 = "1"
-asyncband = "0.6.7"
 mixtrics = "0.2"
 moka = "0.12"
 opentelemetry = { version = "0.32.0" }

--- a/examples/Cargo.toml
+++ b/examples/Cargo.toml
@@ -13,6 +13,12 @@ readme.workspace = true
 exclude.workspace = true
 publish = false
 
+# `tonic` is not used directly in example code, but it must be listed as a dep so the `otel` feature
+# can opt into the tonic-backed gRPC transport for `opentelemetry-otlp` (`grpc-tonic`).
+# Tell cargo-machete to ignore it so CI doesn't flag it as unused.
+[package.metadata.cargo-machete]
+ignored = ["tonic"]
+
 [features]
 serde = ["foyer/serde"]
 otel = [
@@ -53,12 +59,6 @@ tempfile = { workspace = true }
 tokio = { workspace = true, features = ["full"] }
 tonic = { workspace = true, optional = true }
 tracing = { workspace = true }
-
-# `tonic` is not used directly in example code, but it must be listed as a dep so the `otel` feature
-# can opt into the tonic-backed gRPC transport for `opentelemetry-otlp` (`grpc-tonic`).
-# Tell cargo-machete to ignore it so CI doesn't flag it as unused.
-[package.metadata.cargo-machete]
-ignored = ["tonic"]
 
 [[example]]
 name = "memory"

--- a/foyer-bench/Cargo.toml
+++ b/foyer-bench/Cargo.toml
@@ -30,6 +30,7 @@ tracing = [
 
 [dependencies]
 anyhow = { workspace = true }
+asyncband = { workspace = true }
 bytesize = { workspace = true }
 clap = { workspace = true }
 console-subscriber = { workspace = true, optional = true }
@@ -48,7 +49,6 @@ humantime = { workspace = true }
 hyper = { workspace = true, features = ["server", "http1"] }
 hyper-util = { workspace = true, features = ["tokio"] }
 itertools = { workspace = true }
-asyncband = { workspace = true }
 mixtrics = { workspace = true, features = ["prometheus"] }
 opentelemetry = { workspace = true, optional = true }
 opentelemetry-otlp = { workspace = true, features = [

--- a/foyer-memory/Cargo.toml
+++ b/foyer-memory/Cargo.toml
@@ -22,6 +22,7 @@ tracing = ["dep:fastrace", "foyer-common/tracing"]
 
 [dependencies]
 anyhow = { workspace = true }
+asyncband = { workspace = true }
 bitflags = { workspace = true }
 datasketches = { workspace = true, features = ["countmin"] }
 equivalent = { workspace = true }
@@ -31,7 +32,6 @@ futures-util = { workspace = true }
 hashbrown = { workspace = true }
 intrusive-collections = { workspace = true }
 itertools = { workspace = true }
-asyncband = { workspace = true }
 mixtrics = { workspace = true }
 parking_lot = { workspace = true }
 paste = { workspace = true }

--- a/foyer-memory/src/cache.rs
+++ b/foyer-memory/src/cache.rs
@@ -1289,6 +1289,27 @@ mod tests {
         join_all(handles).await;
     }
 
+    #[test]
+    fn test_reinsert_resident_piece() {
+        for pin in [false, true] {
+            let cache: Cache<u64, u64> = CacheBuilder::new(2).with_shards(1).build();
+            let entry = cache.insert(1, 1);
+            drop(cache.insert(2, 2));
+            let pinned = pin.then(|| cache.get(&1).unwrap());
+            let refs = entry.refs();
+            let reinserted = cache.insert_piece(entry.piece());
+            assert_eq!(entry.refs(), refs + 1);
+            assert_eq!(cache.usage(), 2);
+            assert_eq!(*reinserted.value(), 1);
+            assert!(cache.contains(&2));
+            drop((entry, pinned, reinserted));
+            let entry = cache.get(&1).unwrap();
+            assert_eq!(entry.refs(), 1);
+            drop(entry);
+            cache.clear();
+        }
+    }
+
     #[tokio::test]
     async fn test_fifo_cache() {
         case(fifo()).await

--- a/foyer-memory/src/eviction/lru.rs
+++ b/foyer-memory/src/eviction/lru.rs
@@ -213,6 +213,7 @@ where
         };
 
         strict_assert!(!state.link.is_linked());
+        state.is_pinned = false;
 
         record.set_in_eviction(false);
     }
@@ -228,6 +229,7 @@ where
             if state.in_high_priority_pool {
                 state.in_high_priority_pool = false;
             }
+            state.is_pinned = false;
 
             record.set_in_eviction(false);
         }
@@ -522,6 +524,49 @@ pub mod tests {
 
         lru.clear();
         assert_ptr_vec_vec_eq(lru.dump(), vec![vec![], vec![], vec![]]);
+    }
+
+    #[test]
+    fn test_lru_reinsert_pinned_record() {
+        for hint in [Hint::Normal, Hint::Low] {
+            for clear in [false, true] {
+                for acquire in [false, true] {
+                    let record = Arc::new(Record::new(Data {
+                        key: 0u64,
+                        value: 0u64,
+                        properties: TestProperties::default().with_hint(hint),
+                        hash: 0,
+                        weight: 1,
+                    }));
+                    let mut lru = TestLru::new(10, &LruConfig::default());
+                    lru.push(record.clone());
+                    lru.acquire_mutable(&record);
+                    if clear {
+                        lru.clear();
+                    } else {
+                        lru.remove(&record);
+                    }
+                    // A keeper can retain and reinsert the same record after removal.
+                    lru.push(record.clone());
+                    if acquire {
+                        lru.acquire_mutable(&record);
+                        assert_ptr_vec_vec_eq(lru.dump(), vec![vec![], vec![], vec![record.clone()]]);
+                        assert_eq!(lru.high_priority_weight, 0);
+                    }
+                    lru.release_mutable(&record);
+                    let expected = match hint {
+                        Hint::Normal => vec![vec![], vec![record.clone()], vec![]],
+                        Hint::Low => vec![vec![record.clone()], vec![], vec![]],
+                    };
+                    assert_ptr_vec_vec_eq(lru.dump(), expected);
+                    assert_eq!(lru.high_priority_weight, usize::from(hint == Hint::Normal));
+                    lru.remove(&record);
+                    assert_ptr_vec_vec_eq(lru.dump(), vec![vec![], vec![], vec![]]);
+                    assert_eq!(lru.high_priority_weight, 0);
+                    lru.clear();
+                }
+            }
+        }
     }
 
     #[test]

--- a/foyer-memory/src/raw.rs
+++ b/foyer-memory/src/raw.rs
@@ -150,6 +150,17 @@ where
             .take(record.hash(), record.key(), None)
             .unwrap_or_default();
 
+        // Concurrent fetches can return the same record retained by the disk keeper.
+        // Reuse a resident record without unlinking and reinserting it.
+        if record.is_in_indexer() {
+            strict_assert!(self
+                .indexer
+                .get(record.hash(), record.key())
+                .is_some_and(|resident| Arc::ptr_eq(resident, &record)));
+            record.inc_refs(notifiers.len() + 1);
+            return;
+        }
+
         if record.properties().phantom().unwrap_or_default() {
             if let Some(old) = self.indexer.remove(record.hash(), record.key()) {
                 strict_assert!(!old.is_in_indexer());

--- a/foyer-memory/src/raw.rs
+++ b/foyer-memory/src/raw.rs
@@ -153,10 +153,11 @@ where
         // Concurrent fetches can return the same record retained by the disk keeper.
         // Reuse a resident record without unlinking and reinserting it.
         if record.is_in_indexer() {
-            strict_assert!(self
-                .indexer
-                .get(record.hash(), record.key())
-                .is_some_and(|resident| Arc::ptr_eq(resident, &record)));
+            strict_assert!(
+                self.indexer
+                    .get(record.hash(), record.key())
+                    .is_some_and(|resident| Arc::ptr_eq(resident, &record))
+            );
             record.inc_refs(notifiers.len() + 1);
             return;
         }

--- a/foyer-storage/Cargo.toml
+++ b/foyer-storage/Cargo.toml
@@ -28,6 +28,7 @@ strict_assertions = [
 [dependencies]
 allocator-api2 = { workspace = true }
 anyhow = { workspace = true }
+asyncband = { workspace = true }
 bytes = { workspace = true }
 clap = { workspace = true, optional = true }
 equivalent = { workspace = true }
@@ -42,7 +43,6 @@ hashbrown = { workspace = true }
 itertools = { workspace = true }
 libc = { workspace = true }
 lz4 = { workspace = true }
-asyncband = { workspace = true }
 parking_lot = { workspace = true }
 pin-project = { workspace = true }
 rand = { workspace = true, features = ["thread_rng"] }

--- a/foyer/Cargo.toml
+++ b/foyer/Cargo.toml
@@ -43,13 +43,13 @@ runtime-madsim-tokio = ["tokio/runtime-madsim-tokio"]
 
 [dependencies]
 anyhow = { workspace = true }
+asyncband = { workspace = true }
 equivalent = { workspace = true }
 fastrace = { workspace = true, optional = true }
 foyer-common = { workspace = true }
 foyer-memory = { workspace = true }
 foyer-storage = { workspace = true }
 futures-util = { workspace = true }
-asyncband = { workspace = true }
 mixtrics = { workspace = true }
 pin-project = { workspace = true }
 serde = { workspace = true }


### PR DESCRIPTION
Removing a pinned LRU entry left `is_pinned = true` in its record. In a hybrid cache, `insert_piece()` can reinsert the same record without reinitializing its state. The record then enters a high- or low-priority list while still marked as pinned, causing a later release to remove it from the wrong list and corrupt the LRU.

Reset `is_pinned` when removing or clearing pinned records. Also handle concurrent fetches returning the same record: if it is already in the memory cache, reuse it and update its reference count instead of inserting it again.

Add regression tests for both cases, covering list membership, priority weight, reference counts, and preservation of other cached entries.

Fixes #1315.

Validation:

- Both regression scenarios failed before their respective fixes.
- `cargo test -p foyer-memory --features strict_assertions`: 33 tests passed.
- Formatting and diff checks passed.
- The issue's reproducer triggered an LRU assertion failure on 0.22.3. With the fixes, it completed 60 seconds on 0.22.3 and 30 seconds on this branch with strict assertions enabled and task join errors propagated.
