### PR TITLE
chore(deps): bump asyncband to 0.7.1

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,7 +26,12 @@ exclude = ["website/*"]
 [workspace.dependencies]
 allocator-api2 = "0.2"
 anyhow = "1"
-asyncband = "0.6.7"
+asyncband = { version = "0.7.1", features = [
+  "barrier",
+  "mpsc",
+  "mutex",
+  "oneshot",
+] }
 bincode = "1"
 bitflags = "2"
 bytes = "1"


### PR DESCRIPTION
Bump asyncband from 0.6.7 to 0.7.1 and explicitly enable the barrier, mpsc, mutex, and oneshot features used by the workspace, since synchronization primitives are now feature-gated.
