### PR TITLE
chore: release foyer v0.22.5

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,30 @@ date: 2023-05-12T11:02:09+08:00
 
 <!-- truncate -->
 
+## 2026-09-07
+
+### Release
+
+| crate | version |
+| - | - |
+| foyer | 0.22.5 |
+| foyer-tokio | 0.22.5 |
+| foyer-common | 0.22.5 |
+| foyer-memory | 0.22.5 |
+| foyer-storage | 0.22.5 |
+| foyer-bench | 0.22.5 |
+
+### Changes
+
+Fixes:
+
+- Reset pinned state when removing or clearing LRU records so reinserting a retained record preserves eviction list membership and priority weights. [#1339](https://github.com/foyer-rs/foyer/pull/1339)
+- Reuse records already resident in memory when concurrent fetches return the same retained record, preserving reference counts and other cached entries. [#1339](https://github.com/foyer-rs/foyer/pull/1339)
+
+Dependencies:
+
+- Upgrade asyncband to 0.7.1 with explicit barrier, mpsc, mutex, and oneshot features. [#1340](https://github.com/foyer-rs/foyer/pull/1340)
+
 ## 2026-08-31
 
 ### Release

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,7 +12,7 @@ members = [
 ]
 
 [workspace.package]
-version = "0.23.0-dev"
+version = "0.22.5"
 edition = "2024"
 rust-version = "1.91.0"
 repository = "https://github.com/foyer-rs/foyer"
@@ -48,10 +48,10 @@ equivalent = "1"
 fastant = { version = "0.1.11" }
 fastrace = { version = "0.7.18" }
 fastrace-opentelemetry = { version = "0.18.1" }
-foyer = { version = "0.23.0-dev", path = "foyer", default-features = false }
-foyer-common = { version = "0.23.0-dev", path = "foyer-common", default-features = false }
-foyer-memory = { version = "0.23.0-dev", path = "foyer-memory", default-features = false }
-foyer-storage = { version = "0.23.0-dev", path = "foyer-storage", default-features = false }
+foyer = { version = "0.22.5", path = "foyer", default-features = false }
+foyer-common = { version = "0.22.5", path = "foyer-common", default-features = false }
+foyer-memory = { version = "0.22.5", path = "foyer-memory", default-features = false }
+foyer-storage = { version = "0.22.5", path = "foyer-storage", default-features = false }
 fs4 = { version = "0.13", default-features = false }
 futures-core = { version = "0.3" }
 futures-util = { version = "0.3", default-features = false, features = ["std"] }
@@ -90,7 +90,7 @@ serde_json = "1"
 tempfile = "3"
 test-log = "0.2"
 tikv-jemallocator = "0.6"
-tokio = { package = "foyer-tokio", version = "0.23.0-dev", path = "foyer-tokio", default-features = false }
+tokio = { package = "foyer-tokio", version = "0.22.5", path = "foyer-tokio", default-features = false }
 # tonic 0.14.6 bumped its MSRV to 1.88; pin to <0.14.6 to keep the workspace MSRV at 1.86.
 # Pulled in transitively via opentelemetry-otlp (grpc-tonic feature) in `examples`.
 tonic = { version = "0.14.6", default-features = false }


### PR DESCRIPTION
Release foyer 0.22.5 from `main`. Update the shared workspace version and all five internal dependency requirements from `0.23.0-dev` to `0.22.5`, and add the release changelog. The diff against `main` contains only `Cargo.toml` and `CHANGELOG.md`.

This release includes the LRU record reinsertion and reference-count fixes in #1339 and the asyncband 0.7.1 upgrade in #1340. It uses the existing tag-based release workflow: after merging into `main` and passing CI, tag the release commit as `v0.22.5` and approve the `release` environment to publish the crates and create the GitHub Release.

Validation:

- `cargo nextest run --workspace --features strict_assertions`: 105 passed, 1 skipped.
- `cargo test --doc`: passed.
- `cargo +1.91.0 publish --workspace --dry-run --allow-dirty`: all six crates packaged and verified; no uploads performed.
- `cargo semver-checks check-release -p foyer --baseline-rev v0.22.4 --release-type patch --default-features`: 223 checks passed, 31 skipped; no semver update required.
- `cargo fmt --all -- --check`, `typos`, `hawkeye check`, and diff whitespace checks: passed.
- Verified that all dependency settings match `main`; only the six release version fields differ in `Cargo.toml`.

The PR remains a draft pending review and GitHub CI completion.
