### PR TITLE
fix(storage): support musl ioctl request types

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -156,6 +156,26 @@ jobs:
           echo "If you want to pass the test, please install the nightly toolchain with \`rustup install nightly\`."
           echo "Then run \`make ffmt\`."
 
+  rust-musl-check:
+    name: rust musl check
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+        with:
+          persist-credentials: false
+      - name: Install rust toolchain
+        uses: dtolnay/rust-toolchain@master
+        with:
+          toolchain: stable
+          targets: x86_64-unknown-linux-musl
+      - name: Install musl tools
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y musl-tools
+      - name: Check musl build
+        run: cargo check -p foyer --target x86_64-unknown-linux-musl
+
   rust-test:
     name: rust test with codecov
     strategy:

--- a/foyer-storage/src/io/device/utils.rs
+++ b/foyer-storage/src/io/device/utils.rs
@@ -14,33 +14,41 @@
 
 #[cfg(unix)]
 pub fn get_dev_capacity(path: impl AsRef<std::path::Path>) -> foyer_common::error::Result<usize> {
-    use foyer_common::error::Error;
-
-    const BLKGETSIZE64: u64 = 0x80081272;
-    const DIOCGMEDIASIZE: u64 = 0x40086481;
-    const DKIOCGETBLOCKSIZE: u64 = 0x40046418;
-    const DKIOCGETBLOCKCOUNT: u64 = 0x40046419;
-
     use std::{fs::File, os::fd::AsRawFd};
 
     let file = File::open(path.as_ref())?;
     let fd = file.as_raw_fd();
 
-    if cfg!(target_os = "linux") {
+    #[cfg(target_os = "linux")]
+    {
+        const BLKGETSIZE64: u32 = 0x80081272;
+
         let mut size: u64 = 0;
-        let res = unsafe { libc::ioctl(fd, BLKGETSIZE64, &mut size) };
+        // The request is c_ulong on glibc and c_int on musl; preserve its bits when casting.
+        let res = unsafe { libc::ioctl(fd, BLKGETSIZE64 as _, &mut size) };
         if res != 0 {
             return Err(std::io::Error::from_raw_os_error(res).into());
         }
         Ok(size as usize)
-    } else if cfg!(target_os = "freebsd") {
+    }
+
+    #[cfg(target_os = "freebsd")]
+    {
+        const DIOCGMEDIASIZE: libc::c_ulong = 0x40086481;
+
         let mut size: u32 = 0;
         let res = unsafe { libc::ioctl(fd, DIOCGMEDIASIZE, &mut size) };
         if res != 0 {
             return Err(std::io::Error::from_raw_os_error(res).into());
         }
         Ok(size as usize)
-    } else if cfg!(target_os = "macos") {
+    }
+
+    #[cfg(target_os = "macos")]
+    {
+        const DKIOCGETBLOCKSIZE: libc::c_ulong = 0x40046418;
+        const DKIOCGETBLOCKCOUNT: libc::c_ulong = 0x40046419;
+
         let mut block_size: u64 = 0;
         let mut block_count: u64 = 0;
         let res = unsafe { libc::ioctl(fd, DKIOCGETBLOCKSIZE, &mut block_size) };
@@ -53,8 +61,13 @@ pub fn get_dev_capacity(path: impl AsRef<std::path::Path>) -> foyer_common::erro
         }
         let size = block_size * block_count;
         Ok(size as usize)
-    } else {
-        use foyer_common::error::ErrorKind;
+    }
+
+    #[cfg(not(any(target_os = "linux", target_os = "freebsd", target_os = "macos")))]
+    {
+        use foyer_common::error::{Error, ErrorKind};
+
+        let _ = fd;
 
         Err(Error::new(
             ErrorKind::Unsupported,

--- a/foyer-storage/src/io/device/utils.rs
+++ b/foyer-storage/src/io/device/utils.rs
@@ -12,6 +12,15 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+#[cfg(target_os = "linux")]
+const BLKGETSIZE64: u32 = 0x80081272;
+#[cfg(target_os = "freebsd")]
+const DIOCGMEDIASIZE: libc::c_ulong = 0x40086481;
+#[cfg(target_os = "macos")]
+const DKIOCGETBLOCKSIZE: libc::c_ulong = 0x40046418;
+#[cfg(target_os = "macos")]
+const DKIOCGETBLOCKCOUNT: libc::c_ulong = 0x40046419;
+
 #[cfg(unix)]
 pub fn get_dev_capacity(path: impl AsRef<std::path::Path>) -> foyer_common::error::Result<usize> {
     use std::{fs::File, os::fd::AsRawFd};
@@ -21,8 +30,6 @@ pub fn get_dev_capacity(path: impl AsRef<std::path::Path>) -> foyer_common::erro
 
     #[cfg(target_os = "linux")]
     {
-        const BLKGETSIZE64: u32 = 0x80081272;
-
         let mut size: u64 = 0;
         // The request is c_ulong on glibc and c_int on musl; preserve its bits when casting.
         let res = unsafe { libc::ioctl(fd, BLKGETSIZE64 as _, &mut size) };
@@ -34,8 +41,6 @@ pub fn get_dev_capacity(path: impl AsRef<std::path::Path>) -> foyer_common::erro
 
     #[cfg(target_os = "freebsd")]
     {
-        const DIOCGMEDIASIZE: libc::c_ulong = 0x40086481;
-
         let mut size: u32 = 0;
         let res = unsafe { libc::ioctl(fd, DIOCGMEDIASIZE, &mut size) };
         if res != 0 {
@@ -46,9 +51,6 @@ pub fn get_dev_capacity(path: impl AsRef<std::path::Path>) -> foyer_common::erro
 
     #[cfg(target_os = "macos")]
     {
-        const DKIOCGETBLOCKSIZE: libc::c_ulong = 0x40046418;
-        const DKIOCGETBLOCKCOUNT: libc::c_ulong = 0x40046419;
-
         let mut block_size: u64 = 0;
         let mut block_count: u64 = 0;
         let res = unsafe { libc::ioctl(fd, DKIOCGETBLOCKSIZE, &mut block_size) };


### PR DESCRIPTION
Building foyer for musl fails with four `E0308` errors because device-capacity ioctl requests are hard-coded as `u64`, while musl expects `c_int`.

Use `#[cfg]` blocks to compile only the relevant platform implementation. Preserve the Linux request bits with an inferred cast, and type FreeBSD/macOS requests as `libc::c_ulong`. Add a CI job that installs musl tools and checks `foyer` for `x86_64-unknown-linux-musl`.

Validation:
- Reproduced all four type errors on the base revision.
- `cargo check --offline -p foyer --target x86_64-unknown-linux-musl`
- `cargo clippy --offline -p foyer --target x86_64-unknown-linux-gnu -- -D warnings`
- `cargo fmt --all -- --check`
- `git diff --check`

FreeBSD/macOS runtime behavior was not tested locally.

Fixes #1338.
