### PR TITLE
fix(storage): detect noop engine in hybrid mode check

### DIFF
--- a/foyer-storage/src/store.rs
+++ b/foyer-storage/src/store.rs
@@ -12,14 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-use std::{
-    any::{Any, TypeId},
-    borrow::Cow,
-    fmt::Debug,
-    hash::Hash,
-    sync::Arc,
-    time::Instant,
-};
+use std::{any::TypeId, borrow::Cow, fmt::Debug, hash::Hash, sync::Arc, time::Instant};
 
 use equivalent::Equivalent;
 use foyer_common::{
@@ -317,7 +310,7 @@ where
 
     /// If the disk cache is enabled.
     pub fn is_enabled(&self) -> bool {
-        self.inner.engine.type_id() != TypeId::of::<Arc<NoopEngine<K, V, P>>>()
+        self.inner.engine.as_ref().type_id() != TypeId::of::<NoopEngine<K, V, P>>()
     }
 }
 

--- a/foyer/src/hybrid/cache.rs
+++ b/foyer/src/hybrid/cache.rs
@@ -1098,6 +1098,33 @@ mod tests {
     }
 
     #[test_log::test(tokio::test)]
+    async fn test_is_hybrid_in_memory() {
+        let hybrid: HybridCache<u64, u64> = HybridCacheBuilder::new().memory(MB).storage().build().await.unwrap();
+
+        assert_eq!(hybrid.storage().device().capacity(), 0);
+        assert!(!hybrid.storage().is_enabled());
+        assert!(!hybrid.is_hybrid());
+
+        hybrid.insert(1, 1);
+        if hybrid.is_hybrid() {
+            hybrid.flush_if(|_, _| true).await;
+        }
+        assert_eq!(hybrid.memory().get(&1).unwrap().value(), &1);
+        hybrid.close().await.unwrap();
+    }
+
+    #[test_log::test(tokio::test)]
+    async fn test_is_hybrid_with_storage() {
+        let dir = tempfile::tempdir().unwrap();
+        let hybrid = open(dir.path()).await;
+
+        assert!(hybrid.storage().device().capacity() > 0);
+        assert!(hybrid.storage().is_enabled());
+        assert!(hybrid.is_hybrid());
+        hybrid.close().await.unwrap();
+    }
+
+    #[test_log::test(tokio::test)]
     async fn test_hybrid_cache() {
         let dir = tempfile::tempdir().unwrap();
 


### PR DESCRIPTION
Building a hybrid cache without an engine configuration incorrectly reports `is_hybrid() == true`. `Store::is_enabled()` compares the type of the `Arc<dyn Engine>` wrapper with `Arc<NoopEngine>`, so it never recognizes the no-op engine. Inspect the underlying engine's type instead, making memory-only caches return `false` while disk-backed caches continue to return `true`.

Add regression tests for both configurations and for guarding `flush_if()` with `is_hybrid()` to preserve memory-only entries. The memory-only regression fails on the latest main before the fix.

Validation:
- `cargo test -p foyer -p foyer-storage --lib` (37 tests passed)
- `cargo clippy -p foyer -p foyer-storage --lib --tests -- -D warnings`
- `cargo fmt --all -- --check`
- `git diff --check`

Fixes #1333.
