### PR TITLE
chore: release foyer v0.22.6

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,31 @@ date: 2023-05-12T11:02:09+08:00
 
 <!-- truncate -->
 
+## 2026-09-09
+
+### Release
+
+| crate | version |
+| - | - |
+| foyer | 0.22.6 |
+| foyer-tokio | 0.22.6 |
+| foyer-common | 0.22.6 |
+| foyer-memory | 0.22.6 |
+| foyer-storage | 0.22.6 |
+| foyer-bench | 0.22.6 |
+
+### Changes
+
+Features and enhancements:
+
+- Export `PieceRef` so downstream crates can implement the `Engine` trait. [#1330](https://github.com/foyer-rs/foyer/pull/1330)
+
+Fixes:
+
+- Fix musl builds by using platform-appropriate ioctl request types for device capacity detection. [#1342](https://github.com/foyer-rs/foyer/pull/1342)
+- Check the keeper in `Store::may_contains()` so entries still in flight can be reported before they reach the engine index. [#1337](https://github.com/foyer-rs/foyer/pull/1337)
+- Make `HybridCache::is_hybrid()` return `false` when no storage engine is configured, so callers can correctly guard disk-cache operations such as `flush_if()`. [#1343](https://github.com/foyer-rs/foyer/pull/1343)
+
 ## 2026-09-07
 
 ### Release

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,7 +12,7 @@ members = [
 ]
 
 [workspace.package]
-version = "0.22.5"
+version = "0.22.6"
 edition = "2024"
 rust-version = "1.91.0"
 repository = "https://github.com/foyer-rs/foyer"
@@ -48,10 +48,10 @@ equivalent = "1"
 fastant = { version = "0.1.11" }
 fastrace = { version = "0.7.18" }
 fastrace-opentelemetry = { version = "0.18.1" }
-foyer = { version = "0.22.5", path = "foyer", default-features = false }
-foyer-common = { version = "0.22.5", path = "foyer-common", default-features = false }
-foyer-memory = { version = "0.22.5", path = "foyer-memory", default-features = false }
-foyer-storage = { version = "0.22.5", path = "foyer-storage", default-features = false }
+foyer = { version = "0.22.6", path = "foyer", default-features = false }
+foyer-common = { version = "0.22.6", path = "foyer-common", default-features = false }
+foyer-memory = { version = "0.22.6", path = "foyer-memory", default-features = false }
+foyer-storage = { version = "0.22.6", path = "foyer-storage", default-features = false }
 fs4 = { version = "0.13", default-features = false }
 futures-core = { version = "0.3" }
 futures-util = { version = "0.3", default-features = false, features = ["std"] }
@@ -90,7 +90,7 @@ serde_json = "1"
 tempfile = "3"
 test-log = "0.2"
 tikv-jemallocator = "0.6"
-tokio = { package = "foyer-tokio", version = "0.22.5", path = "foyer-tokio", default-features = false }
+tokio = { package = "foyer-tokio", version = "0.22.6", path = "foyer-tokio", default-features = false }
 # tonic 0.14.6 bumped its MSRV to 1.88; pin to <0.14.6 to keep the workspace MSRV at 1.86.
 # Pulled in transitively via opentelemetry-otlp (grpc-tonic feature) in `examples`.
 tonic = { version = "0.14.6", default-features = false }


### PR DESCRIPTION
Release foyer 0.22.6 from `main`. Bump the shared workspace version and all five internal dependency requirements from `0.22.5` to `0.22.6`, and add the release changelog. The diff contains only `Cargo.toml` and `CHANGELOG.md`.

This release includes:

- Export `PieceRef` so downstream crates can implement `Engine` (#1330).
- Fix musl builds by using platform-appropriate ioctl request types (#1342).
- Check the keeper in `Store::may_contains()` for entries still in flight (#1337).
- Make `HybridCache::is_hybrid()` return `false` when no storage engine is configured (#1343).

Validation:

- `cargo nextest run --offline --workspace --features strict_assertions`: 110 passed, 1 skipped.
- `cargo test --offline --doc`: 4 passed.
- `cargo +1.91.0 publish --workspace --dry-run --allow-dirty`: all six crates packaged and verified; no uploads performed.
- `cargo semver-checks check-release -p foyer --baseline-rev v0.22.5 --release-type patch --default-features`: 223 checks passed, 31 skipped; no semver update required.
- `cargo fmt --all -- --check`, `taplo fmt --check`, `typos`, `hawkeye check`, and `git diff --check`: passed.
- Verified that all six publishable crates resolve to `0.22.6` and that the manifest changes only the six release version fields.

The PR remains a draft pending review and GitHub CI completion. After merging into `main` and passing CI, tag the release commit as `v0.22.6` and approve the existing `release` environment to publish the crates and create the GitHub Release.
