### PR TITLE
fix(memory): release the inflight lock before spawning the fetch

### DIFF
--- a/foyer-memory/src/cache.rs
+++ b/foyer-memory/src/cache.rs
@@ -1335,3 +1335,39 @@ mod tests {
         case(sieve()).await
     }
 }
+
+#[cfg(test)]
+mod closing_runtime_tests {
+    use std::sync::{
+        Arc,
+        atomic::{AtomicBool, Ordering},
+    };
+
+    use super::*;
+
+    /// A fetch spawned onto a runtime that is shutting down is cancelled on the spot: tokio drops
+    /// the task's future synchronously on the spawning thread, and `RawFetch::drop` takes the
+    /// inflight lock to dequeue itself. The caller must not still hold that lock when it spawns,
+    /// or the thread deadlocks against itself.
+    #[test]
+    fn a_fetch_spawned_on_a_closing_runtime_does_not_deadlock() {
+        let cache: Cache<u64, u64> = CacheBuilder::new(16).with_shards(1).build();
+        let rt = tokio::runtime::Builder::new_current_thread().build().unwrap();
+        let handle = rt.handle().clone();
+        rt.shutdown_background();
+        let done = Arc::new(AtomicBool::new(false));
+        let d = done.clone();
+        std::thread::spawn(move || {
+            let _enter = handle.enter();
+            drop(cache.get_or_fetch(&1u64, || async { Ok::<_, anyhow::Error>(42u64) }));
+            d.store(true, Ordering::SeqCst);
+        });
+        for _ in 0..50 {
+            if done.load(Ordering::SeqCst) {
+                return;
+            }
+            std::thread::sleep(std::time::Duration::from_millis(100));
+        }
+        panic!("get_or_fetch deadlocked on the inflight lock while the runtime was closing");
+    }
+}

--- a/foyer-memory/src/raw.rs
+++ b/foyer-memory/src/raw.rs
@@ -1088,30 +1088,38 @@ where
                     source: Source::Memory,
                 }))
             })
-            .unwrap_or_else(|| match inflights.lock().enqueue(hash, key, fr()) {
-                Enqueue::Lead {
-                    id,
-                    close,
-                    waiter,
-                    required_fetch_builder,
-                } => {
-                    let fetch = RawFetch {
-                        state: RawFetchState::Init {
-                            optional_fetch_builder: fo(),
-                            required_fetch_builder,
-                        },
+            .unwrap_or_else(|| {
+                // The inflight guard is a temporary of this statement, so it is released before
+                // the spawn below. Spawning while holding it deadlocks when the runtime is
+                // shutting down: tokio cancels a task spawned on a closing runtime synchronously
+                // and drops the fetch on this thread, and `RawFetch::drop` takes the same lock to
+                // dequeue itself.
+                let enqueued = inflights.lock().enqueue(hash, key, fr());
+                match enqueued {
+                    Enqueue::Lead {
                         id,
-                        hash,
-                        key: Some(key.to_owned()),
-                        ctx,
-                        cache: self.clone(),
-                        inflights: inflights.clone(),
                         close,
-                    };
-                    spawner.spawn(fetch);
-                    RawGetOrFetch::Miss(RawWait { waiter })
+                        waiter,
+                        required_fetch_builder,
+                    } => {
+                        let fetch = RawFetch {
+                            state: RawFetchState::Init {
+                                optional_fetch_builder: fo(),
+                                required_fetch_builder,
+                            },
+                            id,
+                            hash,
+                            key: Some(key.to_owned()),
+                            ctx,
+                            cache: self.clone(),
+                            inflights: inflights.clone(),
+                            close,
+                        };
+                        spawner.spawn(fetch);
+                        RawGetOrFetch::Miss(RawWait { waiter })
+                    }
+                    Enqueue::Wait(waiter) => RawGetOrFetch::Miss(RawWait { waiter }),
                 }
-                Enqueue::Wait(waiter) => RawGetOrFetch::Miss(RawWait { waiter }),
             })
         };
 


### PR DESCRIPTION
## What

`get_or_fetch_inner` holds the inflight mutex guard — a temporary of the `match` scrutinee — while it calls `spawner.spawn(fetch)`. When the tokio runtime is shutting down, `spawn` cancels the new task synchronously and drops the future on the spawning thread; `RawFetch::drop` then takes the same non-reentrant lock to dequeue itself, and the thread deadlocks against itself.

This change binds the enqueue result in a `let` first, so the guard is released before the spawn.

## Why

We hit this in a service that uses foyer through SlateDB\x27s block cache: any test process whose runtime shut down while a block fetch was being spawned sat at 0 % CPU forever (four different test binaries, always the same stack: worker thread parked in `parking_lot::RawMutex::lock_slow` from `RawCache::drop` ← `cancel_task` ← `Handle::spawn` ← `get_or_fetch_inner`, test thread waiting in `BlockingPool::shutdown`). The same applies to any process shutdown while a fetch is in flight.

## Test

`closing_runtime_tests::a_fetch_spawned_on_a_closing_runtime_does_not_deadlock`: a `get_or_fetch` issued under a handle whose runtime has been shut down must return. It fails on `main` (5 s watchdog) and passes with this change.
